### PR TITLE
fix(feed): patch build-break from parallel interface refactor

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
@@ -157,11 +157,7 @@ private fun EventListContent(
       verticalArrangement = Arrangement.spacedBy(24.dp)) {
         items(items = events, key = { it.eventId }) { event ->
           EventCard(
-              eventPrice = event.lowestPrice,
-              eventTitle = event.title,
-              eventDate = event.displayDateTime,
-              eventLocation = event.displayLocation,
-              eventOrganizer = event.organizerName,
+              event = event,
               modifier = Modifier.testTag(FeedScreenTestTags.getTestTagForEventItem(event.eventId)),
               onCardClick = { onEventClick(event.eventId) })
         }


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR updates the EventCard composable calls in FeedScreen to match the new interface that accepts a single `Event` parameter instead of individual fields. This resolves compilation errors that occurred due to parallel development work.

## Related issues
Fixes build break caused by EventCard interface changes

## Trade-offs or known limitations
None - this is a straightforward alignment with the new interface.

## How to test
1. Build the project with `./gradlew assembleDebug`
2. Verify the build succeeds without compilation errors
3. Run the app and confirm the feed screen displays events correctly
4. Ensure EventCard functionality remains intact