### PR TITLE
feat(org): define OrganizationRepository interface

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/model/organization/OrganizationRepository.kt
+++ b/app/src/main/java/ch/onepass/onepass/model/organization/OrganizationRepository.kt
@@ -62,8 +62,9 @@ interface OrganizationRepository {
 
   /**
    * Searches for organizations whose names match the given query (case-insensitive prefix match).
+   * Returns an empty list if the query is empty or contains only whitespace.
    *
-   * @param query The search term.
+   * @param query The search term. Empty or whitespace-only queries return empty results.
    * @return A [Flow] emitting a list of matching organizations.
    */
   fun searchOrganizations(query: String): Flow<List<Organization>>
@@ -129,10 +130,11 @@ interface OrganizationRepository {
   fun getPendingInvitations(organizationId: String): Flow<List<OrganizationInvitation>>
 
   /**
-   * Retrieves invitations for a specific email address.
+   * Retrieves invitations for a specific email address. Returns invitations across all statuses
+   * (pending, accepted, rejected, expired, revoked).
    *
    * @param email The email address to search for.
-   * @return A [Flow] emitting a list of invitations for that email.
+   * @return A [Flow] emitting a list of invitations for that email across all statuses.
    */
   fun getInvitationsByEmail(email: String): Flow<List<OrganizationInvitation>>
 


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR defines the `OrganizationRepository` interface, which acts as the abstraction layer for all organization-related data operations. This fulfills the requirements of sub-issue #105.

This contract allows us to:
* Decouple ViewModels from the concrete data implementation (Firestore).
* Easily mock the repository for ViewModel unit testing.

## Related issues
Closes #105 
Part of #84 

## How to test
* This PR only contains an interface, so there are no functional tests.
* Review the file `model/organization/OrganizationRepository.kt`.
* Verify that the interface methods cover all required operations for organizations, members, and invitations as discussed in the original issue.

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.