### PR TITLE
fix(Dimens): increase titleSectionHeight to prevent organizer name cl…

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/theme/Dimens.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/theme/Dimens.kt
@@ -27,7 +27,7 @@ object EventCardDimens {
   val eventCardPadding = 10.dp
 
   // Text section dimensions
-  val titleSectionHeight = 55.17.dp
+  val titleSectionHeight = 60.dp
   val titleTopPadding = 9.dp
   val sectionSpacing = 20.dp
   val dateLocationSpacing = 4.dp


### PR DESCRIPTION
### Changes
- Increase `EventCardDimens.titleSectionHeight` from `55.17.dp` to `60.dp`

### Problem
The organizer name was being cut off when displayed in the EventCard (see screenshot). The fixed height of `55.17.dp` was insufficient to accommodate both the title and organizer text.

### Solution
Increased the `titleSectionHeight` to `60.dp`, allowing both text elements to render fully without clipping.

### Testing
- Verified "Lausanne Food Collective" now displays completely
- All existing EventCard tests pass

## Related issues
- closes #122, fixes part of #47 