### PR TITLE
feat(scan):  Implement TicketScanRepository and Add Tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -160,6 +160,8 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
     // ------------- Firebase ------------------
+    implementation(libs.firebase.functions.ktx)
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.3")
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.auth.ktx)
     implementation(libs.firebase.firestore.ktx)

--- a/app/src/androidTest/java/ch/onepass/onepass/model/pass/TicketScanRepositoryFirebaseTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/model/pass/TicketScanRepositoryFirebaseTest.kt
@@ -1,0 +1,140 @@
+package ch.onepass.onepass.model.scan
+
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.functions.FirebaseFunctions
+import com.google.firebase.functions.HttpsCallableReference
+import com.google.firebase.functions.HttpsCallableResult
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class TicketScanRepositoryFirebaseTest {
+
+  private lateinit var functions: FirebaseFunctions
+  private lateinit var callable: HttpsCallableReference
+  private lateinit var result: HttpsCallableResult
+  private lateinit var repo: TicketScanRepositoryFirebase
+
+  @Before
+  fun setUp() {
+    functions = mockk(relaxed = true)
+    callable = mockk(relaxed = true)
+    result = mockk(relaxed = true)
+
+    // Real repo; inject mocked FirebaseFunctions via reflection (no DI changes needed)
+    repo = TicketScanRepositoryFirebase()
+    repo.javaClass.getDeclaredField("functions").apply {
+      isAccessible = true
+      set(repo, functions)
+    }
+
+    every { functions.getHttpsCallable(any()) } returns callable
+  }
+
+  @Test
+  fun returnsAcceptedDecision() = runTest {
+    val data =
+        mapOf("status" to "accepted", "ticketId" to "T123", "scannedAt" to 111L, "remaining" to 2)
+    every { result.data } returns data
+    every { callable.call(any()) } returns Tasks.forResult(result)
+
+    val res = repo.validateByPass("qr", "event", "device")
+
+    assertTrue(res.isSuccess)
+    val accepted = res.getOrNull() as ScanDecision.Accepted
+    assertEquals("T123", accepted.ticketId)
+    assertEquals(111L, accepted.scannedAtSeconds)
+    assertEquals(2, accepted.remaining)
+  }
+
+  @Test
+  fun acceptedDecisionHandlesIntNumbersAndNullRemaining() = runTest {
+    // scannedAt as Int, remaining absent
+    val data =
+        mapOf(
+            "status" to "ACCEPTED", // uppercase to test lowercase() path
+            "ticketId" to "T999",
+            "scannedAt" to 321, // Int instead of Long
+            // no remaining
+        )
+    every { result.data } returns data
+    every { callable.call(any()) } returns Tasks.forResult(result)
+
+    val res = repo.validateByPass("qr", "event", "device")
+
+    assertTrue(res.isSuccess)
+    val accepted = res.getOrNull() as ScanDecision.Accepted
+    assertEquals("T999", accepted.ticketId)
+    assertEquals(321L, accepted.scannedAtSeconds) // Int → Long
+    assertNull(accepted.remaining) // missing → null
+  }
+
+  @Test
+  fun returnsRejectedDecision() = runTest {
+    val data = mapOf("status" to "rejected", "reason" to "UNREGISTERED", "scannedAt" to 222L)
+    every { result.data } returns data
+    every { callable.call(any()) } returns Tasks.forResult(result)
+
+    val res = repo.validateByPass("qr", "event", "device")
+
+    assertTrue(res.isSuccess)
+    val rejected = res.getOrNull() as ScanDecision.Rejected
+    assertEquals(ScanDecision.Reason.UNREGISTERED, rejected.reason)
+    assertEquals(222L, rejected.scannedAtSeconds)
+  }
+
+  @Test
+  fun rejectedDecisionMapsUnknownReason() = runTest {
+    val data = mapOf("status" to "rejected", "reason" to "SOMETHING_WEIRD", "scannedAt" to 333L)
+    every { result.data } returns data
+    every { callable.call(any()) } returns Tasks.forResult(result)
+
+    val res = repo.validateByPass("qr", "event", "device")
+
+    assertTrue(res.isSuccess)
+    val rejected = res.getOrNull() as ScanDecision.Rejected
+    assertEquals(ScanDecision.Reason.UNKNOWN, rejected.reason)
+    assertEquals(333L, rejected.scannedAtSeconds)
+  }
+
+  @Test
+  fun failsOnEmptyQr() = runTest {
+    val res = repo.validateByPass("", "event", "device")
+    assertTrue(res.isFailure)
+  }
+
+  @Test
+  fun failsOnEmptyEventId() = runTest {
+    val res = repo.validateByPass("qr", "", "device")
+    assertTrue(res.isFailure)
+  }
+
+  @Test
+  fun failsOnEmptyDeviceId() = runTest {
+    val res = repo.validateByPass("qr", "event", "")
+    assertTrue(res.isFailure)
+  }
+
+  @Test
+  fun failsWhenMissingStatusInResponse() = runTest {
+    val data =
+        mapOf( // deliberately no "status"
+            "ticketId" to "T123")
+    every { result.data } returns data
+    every { callable.call(any()) } returns Tasks.forResult(result)
+
+    val res = repo.validateByPass("qr", "event", "device")
+    assertTrue(res.isFailure)
+  }
+
+  @Test
+  fun returnsFailureWhenCloudFunctionThrows() = runTest {
+    every { callable.call(any()) } returns Tasks.forException(RuntimeException("CF down"))
+
+    val res = repo.validateByPass("qr", "event", "device")
+    assertTrue(res.isFailure)
+  }
+}

--- a/app/src/main/java/ch/onepass/onepass/model/scan/ScanDecision.kt
+++ b/app/src/main/java/ch/onepass/onepass/model/scan/ScanDecision.kt
@@ -1,0 +1,18 @@
+package ch.onepass.onepass.model.scan
+sealed class ScanDecision {
+  data class Accepted(
+      val ticketId: String? = null,
+      val scannedAtSeconds: Long? = null,
+      val remaining: Int? = null
+  ) : ScanDecision()
+
+  data class Rejected(val reason: Reason, val scannedAtSeconds: Long? = null) : ScanDecision()
+
+  enum class Reason {
+    UNREGISTERED,
+    ALREADY_SCANNED,
+    BAD_SIGNATURE,
+    REVOKED,
+    UNKNOWN
+  }
+}

--- a/app/src/main/java/ch/onepass/onepass/model/scan/TicketScanRepository.kt
+++ b/app/src/main/java/ch/onepass/onepass/model/scan/TicketScanRepository.kt
@@ -1,0 +1,9 @@
+package ch.onepass.onepass.model.scan
+
+interface TicketScanRepository {
+  suspend fun validateByPass(
+      qrText: String,
+      eventId: String,
+      deviceId: String
+  ): Result<ScanDecision>
+}

--- a/app/src/main/java/ch/onepass/onepass/model/scan/TicketScanRepositoryFirebase.kt
+++ b/app/src/main/java/ch/onepass/onepass/model/scan/TicketScanRepositoryFirebase.kt
@@ -1,0 +1,68 @@
+package ch.onepass.onepass.model.scan
+
+import com.google.firebase.functions.ktx.functions
+import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
+
+/**
+ * Calls Cloud Function to validate a QR pass for an event.
+ *
+ * This class does not parse the QR, does not check Firestore. It only sends the raw QR to backend
+ * and maps the response.
+ */
+class TicketScanRepositoryFirebase : TicketScanRepository {
+
+  private val functions = Firebase.functions
+
+  override suspend fun validateByPass(
+      qrText: String,
+      eventId: String,
+      deviceId: String
+  ): Result<ScanDecision> = runCatching {
+
+    // Basic client-side guardrails — prevents useless requests
+    require(qrText.isNotBlank()) { "QR empty" }
+    require(eventId.isNotBlank()) { "Event ID empty" }
+    require(deviceId.isNotBlank()) { "Device ID empty" }
+
+    // Payload sent to Cloud Function (no parsing here)
+    val payload = mapOf("qrText" to qrText, "eventId" to eventId, "deviceId" to deviceId)
+
+    // Calls backend function: verifies signature + finds ticket + logs scan
+    val result = functions.getHttpsCallable(FN_VALIDATE).call(payload).await()
+
+    // Cloud Function always returns a JSON map
+    @Suppress("UNCHECKED_CAST")
+    val data = result.data as? Map<String, Any?> ?: error("Unexpected CF response format")
+
+    val status =
+        (data[KEY_STATUS] as? String)?.lowercase() ?: error("Missing status in CF response")
+
+    // Accepted flow: backend confirms first scan + updates database
+    if (status == "accepted") {
+      return@runCatching ScanDecision.Accepted(
+          ticketId = data[KEY_TICKET_ID] as? String,
+          scannedAtSeconds = (data[KEY_SCANNED_AT] as? Number)?.toLong(),
+          remaining = (data[KEY_REMAINING] as? Number)?.toInt())
+    }
+
+    // Rejected flow: backend explains reason (unregistered / already scanned / etc.)
+    val reasonStr = (data[KEY_REASON] as? String)?.uppercase() ?: "UNKNOWN"
+    val reason =
+        runCatching { ScanDecision.Reason.valueOf(reasonStr) }
+            .getOrDefault(ScanDecision.Reason.UNKNOWN)
+
+    ScanDecision.Rejected(
+        reason = reason, scannedAtSeconds = (data[KEY_SCANNED_AT] as? Number)?.toLong())
+  }
+
+  private companion object {
+    const val FN_VALIDATE = "validateEntryByPass"
+
+    const val KEY_STATUS = "status"
+    const val KEY_REASON = "reason"
+    const val KEY_TICKET_ID = "ticketId"
+    const val KEY_SCANNED_AT = "scannedAt"
+    const val KEY_REMAINING = "remaining"
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,8 @@ geofirestore = "1.5.0"
 
 
 [libraries]
+firebase-functions-ktx = { module = "com.google.firebase:firebase-functions-ktx" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version = "1.7.3" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
# Title  
Add scan data layer: ScanDecision, TicketScanRepository + Firebase impl & tests

# Description

## Purpose  
Introduce the foundation for ticket scanning.  
This PR adds:

- `ScanDecision` sealed class (accepted / rejected with reason)
- `TicketScanRepository` interface
- `TicketScanRepositoryFirebase` calling `validateEntryByPass`
- Unit tests for success, rejection, wrong input and CF errors

This sets up the data layer for the future ScanViewModel & camera UI.

## Related issue  
Closes #127

## Notes / limitations  
- Cloud Function must return: `status`, `ticketId`, `scannedAt`, `remaining`, `reason`
- Repository only calls CF — no Firestore reads/updates here (handled server-side)
- Tests mock Firebase Functions (not emulator-based for now)

## How to test  
1. Sync project (Functions KTX already included)
2. Run unit tests  
   - Android Studio: `TicketScanRepositoryFirebaseTest`
   - CLI: `./gradlew test`

Tests cover:
- Accepted case: maps `ticketId`, `scannedAt`, `remaining`
- Rejected case: maps enum reasons, fallback to `UNKNOWN`
- Invalid inputs (empty qr/event/device) → failure
- Malformed CF payload → failure
- Cloud Function exception → failure

## Files
- `model/scan/ScanDecision.kt`
- `model/scan/TicketScanRepository.kt`
- `model/scan/TicketScanRepositoryFirebase.kt`
- `model/scan/TicketScanRepositoryFirebaseTest.kt`

## Reviewer notes  
Please verify:
- Correct mapping logic between CF response and domain model
- Error handling using `Result`
- Enum fallback behavior


---

*Note: AI assistance was used to help structure this PR text*

