### PR TITLE
fix(firestore): Update security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,16 +3,7 @@ rules_version='2'
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2025, 11, 7);
+      allow read, write;
     }
   }
 }


### PR DESCRIPTION
This commit removes the temporary, time-based security rule (`allow read, write: if request.time < timestamp.date(2025, 11, 7);`) and replaces it with a permanent open rule (`allow read, write;`).

This change eliminates the default 30-day expiration on database access, making the rules persistent. It also removes the explanatory comments that came with the default rule.