### PR TITLE
feat(edit-event): add ViewModel and core tests

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormViewModelTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormViewModelTest.kt
@@ -89,7 +89,7 @@ class EditEventFormViewModelTest {
     assertEquals("25/12/2025", form.date)
     assertEquals("14:30", form.startTime)
     assertEquals("16:30", form.endTime)
-    assertEquals("25.0", form.price)
+    assertEquals("25", form.price)
     assertEquals("100", form.capacity)
   }
 

--- a/app/src/main/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormViewModel.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormViewModel.kt
@@ -144,8 +144,7 @@ private fun Event.toFormState(): EventFormViewModel.EventFormState {
   val dateString = startTime?.toDate()?.let { dateFormat.format(it) } ?: ""
   val startTimeString = startTime?.toDate()?.let { timeFormat.format(it) } ?: ""
   val endTimeString = endTime?.toDate()?.let { timeFormat.format(it) } ?: ""
-
-  val lowestPrice = pricingTiers.minOfOrNull { it.price } ?: 0.0
+  val lowestPrice = this.lowestPrice
 
   return EventFormViewModel.EventFormState(
       title = title,
@@ -154,6 +153,6 @@ private fun Event.toFormState(): EventFormViewModel.EventFormState {
       endTime = endTimeString,
       date = dateString,
       location = location?.name ?: "",
-      price = if (lowestPrice > 0) lowestPrice.toString() else "0",
+      price = if (lowestPrice > 0u) lowestPrice.toString() else "0",
       capacity = capacity.toString())
 }


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR introduces the ViewModel for the Edit Event feature, as defined in sub-issue #206.

It includes:
* `EditEventFormViewModel` that manages event loading, form state, validation, and updates.
* `EditEventFormState` data class to hold form field values.
* `EditEventUiState` sealed class for managing UI states (Loading, Success, Error, etc.).
* Comprehensive validation for all event fields with clear error messages.
* Initial unit tests covering core functionality including event loading, field updates, and basic validation.

## Related issues
Closes #206  
Part of #205 

## How to test
1. Check out the branch.
2. Run the tests in `EditEventFormViewModelTest.kt` via Android Studio or `./gradlew test`.
3. Verify all 14 core tests pass, covering event loading, field updates, and basic validation.
4. Review the ViewModel implementation in `ui/editform/EditEventFormViewModel.kt` for correctness.

- This is PR 3 of 7 in the Edit Event Form implementation series.

**Related PRs in this series:**
- #224
- #225
- #212 *(this PR)*
- #213 
- #226
- #214
- #215

The product obtained towards the end of this series of 7 PRs is shown below:

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/70f213f4-0ba5-4013-9f45-6bb3a63f2d02" alt="Preloaded Screen" width="300px">
      <br>
      <em>Preloaded Screen</em>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/f15d2d18-599b-4b6d-9cbd-c690c709895a" alt="Time Picker" width="300px">
      <br>
      <em>Time Picker</em>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/5e8d035c-7a65-49cd-b0b0-84fc52bb7c9c" alt="Errors When Trying To Update" width="300px">
      <br>
      <em>Errors When Trying To Update</em>
    </td>
  </tr>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/d3cb4f5b-5285-4961-8984-6631f1833a45" alt="Error Pop Up" width="300px">
      <br>
      <em>Error Pop Up</em>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/bc507e79-6601-42ca-8894-36e945f165fe" alt="Date Picker" width="300px">
      <br>
      <em>Date Picker</em>
    </td>
  </tr>
</table>

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.