### PR TITLE
fix(edit-event): update price field test text matching

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormComposeTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/eventform/editform/EditEventFormComposeTest.kt
@@ -430,7 +430,7 @@ class EditEventFormComposeTest {
     composeTestRule.waitForIdle()
 
     // Find and clear price field
-    composeTestRule.onNodeWithText("25.0").performScrollTo().performTextClearance()
+    composeTestRule.onNodeWithText("25").performScrollTo().performTextClearance()
 
     composeTestRule.onNodeWithText("ex: 12").performTextInput("30.5")
 


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR fixes a small UI test issue in the Edit Event form, as identified during testing.

It includes:
* Correction of the expected text in the price field test from "25.0" to "25"
* Maintains the same test coverage for numeric input functionality
* Ensures the test matches the actual displayed format in the UI

## Related issues
Closes #231 

## How to test
1. Check out the branch.
2. Run the test `priceField_acceptsNumericInput` in `EditEventFormComposeTest.kt`.
3. Verify the test passes with the corrected text matching.
4. Confirm that the price field functionality still works as expected.

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.