### PR TITLE
ci(cd): Update BASE_TAG_START to v1.1.0 in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   MODULE_DIR: app
-  BASE_TAG_START: v1.0.0
+  BASE_TAG_START: v1.1.0
 
 jobs:
   build-release:


### PR DESCRIPTION
This commit updates the `BASE_TAG_START` environment variable in the `cd.yml` GitHub Actions workflow from `v1.0.0` to `v1.1.0`.

**For everyone:**
The merge of this PR will be the signal that all M2 work has been completed.
From the moment this PR is merged until the end of the coach meeting, everyone is not allowed to merge into ⁠ main ⁠.