### PR TITLE
feat(membership): Add membership model for user-organization memberships

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/model/membership/Membership.kt
+++ b/app/src/main/java/ch/onepass/onepass/model/membership/Membership.kt
@@ -10,7 +10,8 @@ import com.google.firebase.firestore.ServerTimestamp
  * This table defines the many-to-many relationship between users and organizations, allowing users
  * to belong to multiple organizations with different roles in each.
  *
- * @property membershipId Unique identifier for the membership record (Firestore document ID).
+ * @property membershipId Unique identifier for the membership record (Firestore document ID),
+ *   nullable before the membership is persisted.
  * @property userId Identifier of the user who is a member of the organization.
  * @property orgId Identifier of the organization the user belongs to.
  * @property role Role assigned to the user within the organization (e.g., OWNER, MEMBER, STAFF).
@@ -18,7 +19,7 @@ import com.google.firebase.firestore.ServerTimestamp
  * @property updatedAt Timestamp when the membership was last updated (server-set).
  */
 data class Membership(
-    val membershipId: String = "",
+    val membershipId: String? = null,
     val userId: String = "",
     val orgId: String = "",
     val role: OrganizationRole = OrganizationRole.MEMBER,

--- a/app/src/test/java/ch/onepass/onepass/model/membership/MembershipTest.kt
+++ b/app/src/test/java/ch/onepass/onepass/model/membership/MembershipTest.kt
@@ -12,7 +12,7 @@ class MembershipTest {
   fun membershipHasCorrectDefaults() {
     val membership = Membership()
 
-    assertEquals("", membership.membershipId)
+    assertNull(membership.membershipId)
     assertEquals("", membership.userId)
     assertEquals("", membership.orgId)
     assertEquals(OrganizationRole.MEMBER, membership.role)


### PR DESCRIPTION
## Description

This PR introduces a new `Membership` data class that defines the membership relationship between users and organizations. This establishes the foundation for managing many-to-many relationships between users and organizations with role-based access control.

## Changes

### Model Definition
- **Created** `Membership` data class in `ch.onepass.onepass.model.membership` package
- **Fields included:**
  - `membershipId`: Unique identifier for the membership record (Firestore document ID)
  - `userId`: Identifier of the user who is a member of the organization
  - `orgId`: Identifier of the organization the user belongs to
  - `role`: Role assigned to the user (uses existing `OrganizationRole` enum: OWNER, MEMBER, STAFF)
  - `createdAt`: Server-set timestamp when the membership was created
  - `updatedAt`: Server-set timestamp when the membership was last updated

### Design Decisions
- **No soft delete**: Membership records are directly deleted from the database when removed (no `deletedAt` field)
- **Simplified naming**: Used `Membership` instead of `UserOrganizationMembership` for brevity, as the context is clear from the package name
- **Package structure**: Created under `ch.onepass.onepass.model.membership` package

### Testing
- **Created** comprehensive test suite `MembershipTest.kt` with 15 test cases covering:
  - Default values validation
  - Property assignment and retrieval
  - All three role types (OWNER, MEMBER, STAFF)
  - Data class functionality (copy, equals, hashCode, toString)
  - Timestamp handling (with and without timestamps)
  - Multi-user and multi-organization scenarios
  - Edge cases and equality comparisons

## Scope

This PR focuses solely on the model definition and does **not** include:
- Repository implementation
- Integration with application logic
- Database migration scripts
- API endpoints or business logic

## Related Issue

Closes #294 

## Testing

All tests pass successfully. The test suite provides comprehensive coverage of the `Membership` data class functionality.

```bash
./gradlew :app:testDebugUnitTest --tests "ch.onepass.onepass.model.membership.MembershipTest"
```

## Files Changed

- `app/src/main/java/ch/onepass/onepass/model/membership/Membership.kt` (new)
- `app/src/test/java/ch/onepass/onepass/model/membership/MembershipTest.kt` (new)

## Clar:
This PR description is written by AI.

