### PR TITLE
fix: remove obsolete Calendar Button from Feed Screen

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/feed/FeedScreenTest.kt
@@ -95,7 +95,6 @@ class FeedScreenTest {
     composeTestRule.onNodeWithTag(FeedScreenTestTags.FEED_TOP_BAR).assertIsDisplayed()
     composeTestRule.onNodeWithTag(FeedScreenTestTags.FEED_TITLE).assertIsDisplayed()
     composeTestRule.onNodeWithTag(FeedScreenTestTags.FEED_LOCATION).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(FeedScreenTestTags.CALENDAR_BUTTON).assertIsDisplayed()
   }
 
   @Test
@@ -127,25 +126,6 @@ class FeedScreenTest {
 
     composeTestRule.onNodeWithTag(FeedScreenTestTags.EMPTY_STATE).assertIsDisplayed()
     composeTestRule.onNodeWithText("No Events Found").assertIsDisplayed()
-  }
-
-  @Test
-  fun feedScreen_calendarButton_isClickable() {
-    val mockRepository = MockEventRepository(emptyList())
-    val viewModel = FeedViewModel(mockRepository)
-    var calendarClicked = false
-
-    composeTestRule.setContent {
-      OnePassTheme {
-        FeedScreen(viewModel = viewModel, onNavigateToCalendar = { calendarClicked = true })
-      }
-    }
-
-    composeTestRule.waitForIdle()
-
-    composeTestRule.onNodeWithTag(FeedScreenTestTags.CALENDAR_BUTTON).performClick()
-
-    assert(calendarClicked)
   }
 
   @Test

--- a/app/src/androidTest/java/ch/onepass/onepass/ui/navigation/AppE2E.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/navigation/AppE2E.kt
@@ -209,10 +209,6 @@ class AppE2E {
       compose.waitForIdle()
     }
 
-    // Open Event Detail and Back
-    compose.onNodeWithTag(FeedScreenTestTags.CALENDAR_BUTTON).assertIsDisplayed().performClick()
-    compose.waitForIdle()
-
     // Ensure Event Detail is displayed
     compose.onNodeWithText("Go Back", useUnmergedTree = true).assertIsDisplayed().performClick()
     compose.waitForIdle()

--- a/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
@@ -33,7 +33,6 @@ object FeedScreenTestTags {
   const val FEED_TITLE = "feedTitle"
   const val FEED_LOCATION = "feedLocation"
   const val FILTER_BUTTON = "filterButton"
-  const val CALENDAR_BUTTON = "calendarButton"
   const val EVENT_LIST = "eventList"
   const val LOADING_INDICATOR = "loadingIndicator"
   const val ERROR_MESSAGE = "errorMessage"
@@ -49,7 +48,6 @@ object FeedScreenTestTags {
  *
  * @param modifier Optional modifier for the screen.
  * @param onNavigateToEvent Callback when an event card is clicked, receives eventId.
- * @param onNavigateToCalendar Callback when calendar button is clicked.
  * @param viewModel FeedViewModel instance, can be overridden for testing.
  * @param filterViewModel EventFilterViewModel instance, providing filter logic.
  */
@@ -58,7 +56,6 @@ object FeedScreenTestTags {
 fun FeedScreen(
     modifier: Modifier = Modifier,
     onNavigateToEvent: (String) -> Unit = {},
-    onNavigateToCalendar: () -> Unit = {},
     viewModel: FeedViewModel = viewModel(),
     filterViewModel: EventFilterViewModel = viewModel(),
 ) {
@@ -81,7 +78,6 @@ fun FeedScreen(
           FeedTopBar(
               currentLocation = uiState.location,
               currentDateRange = "WELCOME",
-              onCalendarClick = onNavigateToCalendar,
               onFilterClick = { viewModel.setShowFilterDialog(true) },
           )
           if (currentFilters.hasActiveFilters) {
@@ -143,7 +139,6 @@ fun FeedScreen(
  *
  * @param currentLocation The string representing the current user location or selected region.
  * @param currentDateRange The string representing the current date range filter.
- * @param onCalendarClick Callback invoked when the calendar button is clicked.
  * @param onFilterClick Callback invoked when the filter button is clicked.
  * @param modifier Optional modifier for the top bar.
  */
@@ -151,7 +146,6 @@ fun FeedScreen(
 private fun FeedTopBar(
     currentLocation: String,
     currentDateRange: String,
-    onCalendarClick: () -> Unit,
     onFilterClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -194,18 +188,6 @@ private fun FeedTopBar(
             Icon(
                 painter = painterResource(id = R.drawable.filter_icon),
                 contentDescription = "Filter events",
-                tint = Color.White,
-                modifier = Modifier.size(24.dp),
-            )
-          }
-
-          IconButton(
-              onClick = onCalendarClick,
-              modifier = Modifier.size(48.dp).testTag(FeedScreenTestTags.CALENDAR_BUTTON),
-          ) {
-            Icon(
-                painter = painterResource(id = R.drawable.calendar),
-                contentDescription = "Calendar view",
                 tint = Color.White,
                 modifier = Modifier.size(24.dp),
             )

--- a/app/src/main/java/ch/onepass/onepass/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/navigation/AppNavHost.kt
@@ -101,7 +101,7 @@ fun AppNavHost(
           onNavigateToEvent = { eventId ->
             navController.navigate(Screen.EventDetail.route(eventId))
           },
-          onNavigateToCalendar = { navController.navigate(Screen.ComingSoon.route) })
+      )
     }
 
     // ------------------ Event Detail ------------------


### PR DESCRIPTION
# Description

## Purpose of the change
This PR removes the obsolete calendar button from the `FeedScreen` to clean up the **UI** and its **Kdoc**. Since **date filtering** is now fully handled through the `FilterDialog`, the standalone button is redundant. The removal required refactoring related code in `AppNavHost.kt`, `FeedScreenTest.kt`, and `AppE2E.kt` to ensure all references are cleaned up and tests remain consistent with the updated interface.

## Related issues
Closes #233

## How to test
* Check out the branch.  
* Run the app and navigate to the feed screen.  
* Verify that:
  - The calendar button is no longer visible in the `FeedScreen` header.
  - Date filtering continues to work correctly via the `FilterDialog`.
  - All unit and end-to-end tests pass.


<p align="center">
<strong>Before</strong><br>
<img width="353" height="68" alt="Screenshot from 2025-11-20 12-00-08" src="https://github.com/user-attachments/assets/92603cbd-98de-4c72-9846-c77f2b7a824c" />
<br><br>
<strong>After</strong><br>
<img width="353" height="68" alt="Screenshot from 2025-11-20 12-04-44" src="https://github.com/user-attachments/assets/ac6d6eb5-1ea8-435b-b662-8a9b5c5cbcdf" />
</p>

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.