### PR TITLE
fix: replace hardcoded colors with XML color resources

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/auth/AuthScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/auth/AuthScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -60,7 +61,7 @@ fun AuthScreen(onSignedIn: () -> Unit = {}, authViewModel: AuthViewModel = AuthV
                           .offset(x = (-190).dp, y = (-380).dp),
                   size = 481.dp,
                   blurRadius = 40.dp,
-                  color = Color(0xFF683F88))
+                  color = colorResource(id = R.color.blur_circle_top))
 
               BlurCircle(
                   modifier =
@@ -68,8 +69,7 @@ fun AuthScreen(onSignedIn: () -> Unit = {}, authViewModel: AuthViewModel = AuthV
                           .offset(x = (200).dp, y = (130).dp),
                   size = 200.dp,
                   blurRadius = 40.dp,
-                  color = Color(0xFF4B210A),
-              )
+                  color = colorResource(id = R.color.blur_circle_bottom))
 
               Logo(
                   modifier =

--- a/app/src/main/java/ch/onepass/onepass/ui/components/buttons/LikeButton.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/components/buttons/LikeButton.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import ch.onepass.onepass.R
 
 /**
  * Like button component with heart icon that toggles between liked and unliked states
@@ -49,7 +51,7 @@ fun LikeButton(isLiked: Boolean, onLikeToggle: (Boolean) -> Unit, modifier: Modi
         Icon(
             imageVector = if (isLiked) Icons.Filled.Favorite else Icons.Outlined.FavoriteBorder,
             contentDescription = if (isLiked) "Unlike" else "Like",
-            tint = if (isLiked) Color(0xFFE91E63) else Color.White,
+            tint = if (isLiked) colorResource(id = R.color.heart_liked) else Color.White,
             modifier = Modifier.size(24.dp).scale(scale))
       }
 }

--- a/app/src/main/java/ch/onepass/onepass/ui/components/common/StateDisplays.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/components/common/StateDisplays.kt
@@ -5,11 +5,12 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import ch.onepass.onepass.R
 import ch.onepass.onepass.ui.theme.EventDateColor
 
 /** Generic loading state indicator. */
@@ -38,13 +39,13 @@ fun ErrorState(
         text = "Oops!",
         style = MaterialTheme.typography.headlineMedium,
         fontWeight = FontWeight.Bold,
-        color = Color.White,
+        color = colorResource(R.color.white),
     )
     Spacer(modifier = Modifier.height(8.dp))
     Text(
         text = error,
         style = MaterialTheme.typography.bodyMedium,
-        color = Color(0xFF9CA3AF),
+        color = colorResource(R.color.state_display_text),
         textAlign = TextAlign.Center,
     )
     Spacer(modifier = Modifier.height(24.dp))
@@ -54,7 +55,7 @@ fun ErrorState(
         colors =
             ButtonDefaults.buttonColors(
                 containerColor = EventDateColor,
-                contentColor = Color.White,
+                contentColor = colorResource(R.color.white),
             ),
     ) {
       Text(text = "Try Again", fontWeight = FontWeight.Medium)
@@ -79,13 +80,13 @@ fun EmptyState(
         text = title,
         style = MaterialTheme.typography.headlineMedium,
         fontWeight = FontWeight.Bold,
-        color = Color.White,
+        color = colorResource(R.color.white),
     )
     Spacer(modifier = Modifier.height(8.dp))
     Text(
         text = message,
         style = MaterialTheme.typography.bodyMedium,
-        color = Color(0xFF9CA3AF),
+        color = colorResource(R.color.state_display_text),
         textAlign = TextAlign.Center,
     )
   }

--- a/app/src/main/java/ch/onepass/onepass/ui/components/forms/DateTimePicker.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/components/forms/DateTimePicker.kt
@@ -10,8 +10,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -47,7 +47,9 @@ fun TimePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
   Box(
       modifier =
           modifier
-              .background(Color(0xFF767680).copy(alpha = 0.12f), RoundedCornerShape(6.dp))
+              .background(
+                  colorResource(id = R.color.time_picker_background).copy(alpha = 0.12f),
+                  RoundedCornerShape(6.dp))
               .clip(RoundedCornerShape(6.dp))
               .clickable { showDialog = true }
               .padding(horizontal = 12.dp, vertical = 14.dp),
@@ -56,7 +58,9 @@ fun TimePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
             text = value.ifEmpty { "${Calendar.HOUR_OF_DAY}:${Calendar.MINUTE}" },
             style =
                 MaterialTheme.typography.headlineSmall.copy(
-                    color = if (value.isEmpty()) Color.Gray else Color.Black))
+                    color =
+                        if (value.isEmpty()) colorResource(id = R.color.gray)
+                        else colorResource(id = R.color.black)))
       }
 
   if (showDialog) {
@@ -66,33 +70,45 @@ fun TimePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
           Surface(
               modifier = Modifier.fillMaxWidth(0.9f).wrapContentHeight(),
               shape = RoundedCornerShape(16.dp),
-              color = Color(0xFF1C1C1C)) {
+              color = colorResource(id = R.color.date_picker_background)) {
                 Column(
                     modifier = Modifier.padding(24.dp),
                     horizontalAlignment = Alignment.CenterHorizontally) {
                       Text(
                           text = "Select Time",
-                          style = MaterialTheme.typography.titleLarge.copy(color = Color.White),
+                          style =
+                              MaterialTheme.typography.titleLarge.copy(
+                                  color = colorResource(id = R.color.white)),
                           modifier = Modifier.padding(bottom = 16.dp))
 
                       TimePicker(
                           state = timePickerState,
                           colors =
                               TimePickerDefaults.colors(
-                                  clockDialColor = Color(0xFF262626),
+                                  clockDialColor =
+                                      colorResource(id = R.color.date_picker_background_darker),
                                   selectorColor = EventDateColor,
-                                  containerColor = Color(0xFF1C1C1C),
-                                  periodSelectorBorderColor = Color(0xFF404040),
-                                  clockDialSelectedContentColor = Color.White,
-                                  clockDialUnselectedContentColor = Color.Gray,
+                                  containerColor =
+                                      colorResource(id = R.color.date_picker_background),
+                                  periodSelectorBorderColor =
+                                      colorResource(id = R.color.date_picker_border),
+                                  clockDialSelectedContentColor = colorResource(id = R.color.white),
+                                  clockDialUnselectedContentColor =
+                                      colorResource(id = R.color.gray),
                                   periodSelectorSelectedContainerColor = EventDateColor,
-                                  periodSelectorUnselectedContainerColor = Color(0xFF262626),
-                                  periodSelectorSelectedContentColor = Color.White,
-                                  periodSelectorUnselectedContentColor = Color.Gray,
+                                  periodSelectorUnselectedContainerColor =
+                                      colorResource(id = R.color.date_picker_background_darker),
+                                  periodSelectorSelectedContentColor =
+                                      colorResource(id = R.color.white),
+                                  periodSelectorUnselectedContentColor =
+                                      colorResource(id = R.color.gray),
                                   timeSelectorSelectedContainerColor = EventDateColor,
-                                  timeSelectorUnselectedContainerColor = Color(0xFF262626),
-                                  timeSelectorSelectedContentColor = Color.White,
-                                  timeSelectorUnselectedContentColor = Color.Gray))
+                                  timeSelectorUnselectedContainerColor =
+                                      colorResource(id = R.color.date_picker_background_darker),
+                                  timeSelectorSelectedContentColor =
+                                      colorResource(id = R.color.white),
+                                  timeSelectorUnselectedContentColor =
+                                      colorResource(id = R.color.gray)))
 
                       Row(
                           modifier = Modifier.fillMaxWidth().padding(top = 24.dp),
@@ -102,7 +118,8 @@ fun TimePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
                               Text(
                                   "Cancel",
                                   style =
-                                      MaterialTheme.typography.labelLarge.copy(color = Color.White))
+                                      MaterialTheme.typography.labelLarge.copy(
+                                          color = colorResource(id = R.color.white)))
                             }
                             Spacer(modifier = Modifier.width(8.dp))
                             Button(
@@ -149,8 +166,10 @@ fun DatePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
   Box(
       modifier =
           modifier
-              .background(Color(0xFF1C1C1C), RoundedCornerShape(6.dp))
-              .border(1.dp, Color(0xFF404040), RoundedCornerShape(6.dp))
+              .background(
+                  colorResource(id = R.color.date_picker_background), RoundedCornerShape(6.dp))
+              .border(
+                  1.dp, colorResource(id = R.color.date_picker_border), RoundedCornerShape(6.dp))
               .clip(RoundedCornerShape(6.dp))
               .clickable { showDialog = true }
               .padding(horizontal = 16.dp, vertical = 14.dp),
@@ -163,50 +182,55 @@ fun DatePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
                   text = value.ifEmpty { "Select date" },
                   style =
                       MaterialTheme.typography.bodyMedium.copy(
-                          color = if (value.isEmpty()) Color(0xFF6C757D) else Color.White))
+                          color =
+                              if (value.isEmpty())
+                                  colorResource(id = R.color.date_picker_text_secondary)
+                              else colorResource(id = R.color.white)))
               Icon(
                   imageVector = ImageVector.vectorResource(R.drawable.choosedateicon),
                   contentDescription = "Select date",
-                  tint = Color.Gray,
+                  tint = colorResource(id = R.color.gray),
                   modifier = Modifier.size(20.dp))
             }
       }
   if (showDialog) {
     val datePickerColors =
         DatePickerDefaults.colors(
-            containerColor = Color(0xFF1C1C1C),
-            titleContentColor = Color.White,
-            headlineContentColor = Color.White,
-            weekdayContentColor = Color.Gray,
-            subheadContentColor = Color.White,
-            yearContentColor = Color.White,
-            currentYearContentColor = Color.White,
-            selectedYearContentColor = Color.White,
+            containerColor = colorResource(id = R.color.date_picker_background),
+            titleContentColor = colorResource(id = R.color.white),
+            headlineContentColor = colorResource(id = R.color.white),
+            weekdayContentColor = colorResource(id = R.color.gray),
+            subheadContentColor = colorResource(id = R.color.white),
+            yearContentColor = colorResource(id = R.color.white),
+            currentYearContentColor = colorResource(id = R.color.white),
+            selectedYearContentColor = colorResource(id = R.color.white),
             selectedYearContainerColor = EventDateColor,
-            dayContentColor = Color.White,
-            disabledDayContentColor = Color.Gray,
-            selectedDayContentColor = Color.White,
-            disabledSelectedDayContentColor = Color.Gray,
+            dayContentColor = colorResource(id = R.color.white),
+            disabledDayContentColor = colorResource(id = R.color.gray),
+            selectedDayContentColor = colorResource(id = R.color.white),
+            disabledSelectedDayContentColor = colorResource(id = R.color.gray),
             selectedDayContainerColor = EventDateColor,
             todayContentColor = EventDateColor,
             todayDateBorderColor = EventDateColor,
-            dayInSelectionRangeContentColor = Color.White,
+            dayInSelectionRangeContentColor = colorResource(id = R.color.white),
             dayInSelectionRangeContainerColor = EventDateColor.copy(alpha = 0.3f),
-            dividerColor = Color(0xFF404040),
+            dividerColor = colorResource(id = R.color.date_picker_border),
             dateTextFieldColors =
                 TextFieldDefaults.colors(
-                    focusedContainerColor = Color(0xFF262626),
-                    unfocusedContainerColor = Color(0xFF262626),
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
-                    disabledTextColor = Color.White,
+                    focusedContainerColor =
+                        colorResource(id = R.color.date_picker_background_darker),
+                    unfocusedContainerColor =
+                        colorResource(id = R.color.date_picker_background_darker),
+                    focusedTextColor = colorResource(id = R.color.white),
+                    unfocusedTextColor = colorResource(id = R.color.white),
+                    disabledTextColor = colorResource(id = R.color.white),
                     cursorColor = EventDateColor,
                     focusedIndicatorColor = EventDateColor,
-                    unfocusedIndicatorColor = Color(0xFF404040),
-                    disabledIndicatorColor = Color(0xFF404040),
+                    unfocusedIndicatorColor = colorResource(id = R.color.date_picker_border),
+                    disabledIndicatorColor = colorResource(id = R.color.date_picker_border),
                     focusedLabelColor = EventDateColor,
-                    unfocusedLabelColor = Color.Gray,
-                    disabledLabelColor = Color.Gray))
+                    unfocusedLabelColor = colorResource(id = R.color.gray),
+                    disabledLabelColor = colorResource(id = R.color.gray)))
 
     DatePickerDialog(
         onDismissRequest = { showDialog = false },
@@ -226,7 +250,11 @@ fun DatePickerField(value: String, onValueChange: (String) -> Unit, modifier: Mo
         },
         dismissButton = {
           TextButton(onClick = { showDialog = false }) {
-            Text("Cancel", style = MaterialTheme.typography.labelLarge.copy(color = Color.White))
+            Text(
+                "Cancel",
+                style =
+                    MaterialTheme.typography.labelLarge.copy(
+                        color = colorResource(id = R.color.white)))
           }
         },
         colors = datePickerColors) {

--- a/app/src/main/java/ch/onepass/onepass/ui/components/forms/LocationSearchField.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/components/forms/LocationSearchField.kt
@@ -9,9 +9,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import ch.onepass.onepass.R
 import ch.onepass.onepass.model.map.Location
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -43,7 +45,7 @@ fun LocationSearchField(
             text = "Location*",
             style =
                 MaterialTheme.typography.bodyMedium.copy(
-                    color = Color(0xFFFFFFFF), textAlign = TextAlign.Center),
+                    color = colorResource(id = R.color.white), textAlign = TextAlign.Center),
             modifier = Modifier.fillMaxWidth())
 
         ExposedDropdownMenuBox(
@@ -58,14 +60,19 @@ fun LocationSearchField(
                   onValueChange = onQueryChange,
                   modifier =
                       Modifier.fillMaxWidth()
-                          .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))
+                          .border(
+                              1.dp,
+                              colorResource(id = R.color.location_field_border),
+                              RoundedCornerShape(10.dp))
                           .heightIn(min = 50.dp)
                           .menuAnchor()
                           .testTag(testTag),
                   placeholder = {
                     Text(
                         "Type to search location",
-                        style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray))
+                        style =
+                            MaterialTheme.typography.bodySmall.copy(
+                                color = colorResource(id = R.color.gray)))
                   },
                   trailingIcon = {
                     if (isLoading) {
@@ -74,12 +81,14 @@ fun LocationSearchField(
                   },
                   colors =
                       TextFieldDefaults.colors(
-                          focusedContainerColor = Color(0xFF1C1C1C),
-                          unfocusedContainerColor = Color(0xFF1C1C1C),
+                          focusedContainerColor =
+                              colorResource(id = R.color.location_field_container),
+                          unfocusedContainerColor =
+                              colorResource(id = R.color.location_field_container),
                           focusedIndicatorColor = Color.Transparent,
                           unfocusedIndicatorColor = Color.Transparent,
-                          focusedTextColor = Color.White,
-                          unfocusedTextColor = Color.White,
+                          focusedTextColor = colorResource(id = R.color.white),
+                          unfocusedTextColor = colorResource(id = R.color.white),
                       ),
                   shape = RoundedCornerShape(10.dp),
                   textStyle = MaterialTheme.typography.bodySmall,

--- a/app/src/main/java/ch/onepass/onepass/ui/eventdetail/EventDetailScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventdetail/EventDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -168,8 +169,7 @@ private fun BuyButton(
           shape = RoundedCornerShape(5.dp),
           colors =
               ButtonDefaults.buttonColors(
-                  containerColor = Color(0xFF413857) // Purple from design
-                  )) {
+                  containerColor = colorResource(id = R.color.event_buy_button_bg))) {
             Text(
                 text = priceText,
                 style =
@@ -187,7 +187,7 @@ private fun BackSection(onBack: () -> Unit) {
   Row(
       modifier =
           Modifier.fillMaxWidth()
-              .background(Color(0xFF1A1A1A)) // Semi-transparent black
+              .background(colorResource(id = R.color.event_back_section_bg))
               .height(79.dp)
               .padding(start = 22.dp, top = 55.dp, end = 22.dp, bottom = 6.dp)
               .testTag(EventDetailTestTags.TITLE),
@@ -360,7 +360,7 @@ private fun EventDetailsSection(
                 imageVector = Icons.Default.CalendarToday,
                 contentDescription = null,
                 modifier = Modifier.size(26.dp),
-                tint = Color(0xFFA3A3A3))
+                tint = colorResource(id = R.color.event_icon_gray))
             Text(
                 text = event.displayDateTime,
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
@@ -377,7 +377,7 @@ private fun EventDetailsSection(
                 imageVector = Icons.Default.LocationCity,
                 contentDescription = null,
                 modifier = Modifier.size(26.dp),
-                tint = Color(0xFFA3A3A3))
+                tint = colorResource(id = R.color.event_icon_gray))
             Text(
                 text = event.displayLocation,
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium),
@@ -390,7 +390,8 @@ private fun EventDetailsSection(
     Row(
         modifier =
             Modifier.fillMaxWidth()
-                .border(1.dp, Color(0xFF242424), RoundedCornerShape(0.dp))
+                .border(
+                    1.dp, colorResource(id = R.color.event_border_gray), RoundedCornerShape(0.dp))
                 .clickable(onClick = onNavigateToMap)
                 .padding(vertical = 14.dp, horizontal = 16.dp)
                 .testTag(EventDetailTestTags.MAP_BUTTON),

--- a/app/src/main/java/ch/onepass/onepass/ui/eventform/EventFormFields.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventform/EventFormFields.kt
@@ -11,8 +11,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import ch.onepass.onepass.R
 import ch.onepass.onepass.ui.components.forms.DatePickerField
 import ch.onepass.onepass.ui.components.forms.LocationSearchField
 import ch.onepass.onepass.ui.components.forms.TimePickerField
@@ -26,28 +28,34 @@ fun TitleInputField(value: String, onValueChange: (String) -> Unit, modifier: Mo
       modifier = modifier.fillMaxWidth()) {
         Text(
             text = "Title*",
-            style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFFFFFFFF)))
+            style =
+                MaterialTheme.typography.bodyMedium.copy(color = colorResource(id = R.color.white)))
         TextField(
             value = value,
             onValueChange = onValueChange,
             placeholder = {
               Text(
                   "Amazing event",
-                  style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray))
+                  style =
+                      MaterialTheme.typography.bodySmall.copy(
+                          color = colorResource(id = R.color.gray)))
             },
             modifier =
                 Modifier.fillMaxWidth()
-                    .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))
+                    .border(
+                        1.dp,
+                        colorResource(id = R.color.eventform_field_border),
+                        RoundedCornerShape(10.dp))
                     .heightIn(min = 50.dp)
                     .testTag("title_input_field"),
             colors =
                 TextFieldDefaults.colors(
-                    focusedContainerColor = Color(0xFF1C1C1C),
-                    unfocusedContainerColor = Color(0xFF1C1C1C),
+                    focusedContainerColor = colorResource(id = R.color.eventform_field_bg),
+                    unfocusedContainerColor = colorResource(id = R.color.eventform_field_bg),
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
-                    focusedTextColor = Color.White,
-                    unfocusedTextColor = Color.White,
+                    focusedTextColor = colorResource(id = R.color.white),
+                    unfocusedTextColor = colorResource(id = R.color.white),
                 ),
             shape = RoundedCornerShape(10.dp),
             textStyle = MaterialTheme.typography.bodySmall,
@@ -69,30 +77,35 @@ fun DescriptionInputField(
   ) {
     Text(
         text = "Description*",
-        style = MaterialTheme.typography.bodyMedium.copy(color = Color(0xFFFFFFFF)))
+        style = MaterialTheme.typography.bodyMedium.copy(color = colorResource(id = R.color.white)))
 
     Box(
         modifier =
             Modifier.fillMaxWidth()
                 .height(122.dp)
-                .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))) {
+                .border(
+                    1.dp,
+                    colorResource(id = R.color.eventform_field_border),
+                    RoundedCornerShape(10.dp))) {
           TextField(
               value = value,
               onValueChange = onValueChange,
               placeholder = {
                 Text(
                     "This is amazing..",
-                    style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray))
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            color = colorResource(id = R.color.gray)))
               },
               modifier = Modifier.fillMaxSize().testTag("description_input_field"),
               colors =
                   TextFieldDefaults.colors(
-                      focusedContainerColor = Color(0xFF1C1C1C),
-                      unfocusedContainerColor = Color(0xFF1C1C1C),
+                      focusedContainerColor = colorResource(id = R.color.eventform_field_bg),
+                      unfocusedContainerColor = colorResource(id = R.color.eventform_field_bg),
                       focusedIndicatorColor = Color.Transparent,
                       unfocusedIndicatorColor = Color.Transparent,
-                      focusedTextColor = Color.White,
-                      unfocusedTextColor = Color.White,
+                      focusedTextColor = colorResource(id = R.color.white),
+                      unfocusedTextColor = colorResource(id = R.color.white),
                   ),
               shape = RoundedCornerShape(10.dp),
               textStyle = MaterialTheme.typography.bodySmall,
@@ -117,14 +130,19 @@ fun TimeInputField(
             text = "Date & time*",
             style =
                 MaterialTheme.typography.bodyMedium.copy(
-                    color = Color(0xFFFFFFFF), textAlign = TextAlign.Center),
+                    color = colorResource(id = R.color.white), textAlign = TextAlign.Center),
             modifier = Modifier.fillMaxWidth())
 
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .background(Color(0xFF1C1C1C), shape = RoundedCornerShape(10.dp))
-                    .border(1.dp, Color(0xFF404040), shape = RoundedCornerShape(10.dp))
+                    .background(
+                        colorResource(id = R.color.eventform_field_bg),
+                        shape = RoundedCornerShape(10.dp))
+                    .border(
+                        1.dp,
+                        colorResource(id = R.color.eventform_field_border),
+                        shape = RoundedCornerShape(10.dp))
                     .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)) {
               Row(
@@ -134,7 +152,9 @@ fun TimeInputField(
                     Column(horizontalAlignment = Alignment.Start) {
                       Text(
                           text = "Start time",
-                          style = MaterialTheme.typography.bodySmall.copy(color = Color.White))
+                          style =
+                              MaterialTheme.typography.bodySmall.copy(
+                                  color = colorResource(id = R.color.white)))
                       Spacer(modifier = Modifier.height(4.dp))
                       TimePickerField(
                           value = startTimeValue,
@@ -144,7 +164,9 @@ fun TimeInputField(
                     Column(horizontalAlignment = Alignment.Start) {
                       Text(
                           text = "End time",
-                          style = MaterialTheme.typography.bodySmall.copy(color = Color.White))
+                          style =
+                              MaterialTheme.typography.bodySmall.copy(
+                                  color = colorResource(id = R.color.white)))
                       Spacer(modifier = Modifier.height(4.dp))
                       TimePickerField(
                           value = endTimeValue,
@@ -207,7 +229,7 @@ fun TicketsInputField(
         text = "Tickets*",
         style =
             MaterialTheme.typography.bodyMedium.copy(
-                color = Color(0xFFFFFFFF), textAlign = TextAlign.Center),
+                color = colorResource(id = R.color.white), textAlign = TextAlign.Center),
         modifier = Modifier.fillMaxWidth())
 
     Row(
@@ -218,30 +240,39 @@ fun TicketsInputField(
           Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = "Price",
-                style = MaterialTheme.typography.bodySmall.copy(color = Color.White))
+                style =
+                    MaterialTheme.typography.bodySmall.copy(
+                        color = colorResource(id = R.color.white)))
             Spacer(modifier = Modifier.height(4.dp))
             Box(
                 modifier =
                     Modifier.width(90.dp)
                         .height(50.dp)
-                        .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))) {
+                        .border(
+                            1.dp,
+                            colorResource(id = R.color.eventform_field_border),
+                            RoundedCornerShape(10.dp))) {
                   TextField(
                       value = priceValue,
                       onValueChange = onPriceChange,
                       placeholder = {
                         Text(
                             "ex: 12",
-                            style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray))
+                            style =
+                                MaterialTheme.typography.bodySmall.copy(
+                                    color = colorResource(id = R.color.gray)))
                       },
                       modifier = Modifier.fillMaxSize().testTag("price_input_field"),
                       colors =
                           TextFieldDefaults.colors(
-                              focusedContainerColor = Color(0xFF1C1C1C),
-                              unfocusedContainerColor = Color(0xFF1C1C1C),
+                              focusedContainerColor =
+                                  colorResource(id = R.color.eventform_field_bg),
+                              unfocusedContainerColor =
+                                  colorResource(id = R.color.eventform_field_bg),
                               focusedIndicatorColor = Color.Transparent,
                               unfocusedIndicatorColor = Color.Transparent,
-                              focusedTextColor = Color.White,
-                              unfocusedTextColor = Color.White,
+                              focusedTextColor = colorResource(id = R.color.white),
+                              unfocusedTextColor = colorResource(id = R.color.white),
                           ),
                       shape = RoundedCornerShape(10.dp),
                       textStyle = MaterialTheme.typography.bodySmall,
@@ -252,7 +283,7 @@ fun TicketsInputField(
               priceError?.let {
                 Text(
                     text = it,
-                    color = Color.Red,
+                    color = colorResource(id = R.color.error_red),
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1)
               }
@@ -263,30 +294,39 @@ fun TicketsInputField(
           Column(modifier = Modifier.weight(1f), horizontalAlignment = Alignment.End) {
             Text(
                 text = "Capacity",
-                style = MaterialTheme.typography.bodySmall.copy(color = Color.White))
+                style =
+                    MaterialTheme.typography.bodySmall.copy(
+                        color = colorResource(id = R.color.white)))
             Spacer(modifier = Modifier.height(4.dp))
             Box(
                 modifier =
                     Modifier.width(90.dp)
                         .height(50.dp)
-                        .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))) {
+                        .border(
+                            1.dp,
+                            colorResource(id = R.color.eventform_field_border),
+                            RoundedCornerShape(10.dp))) {
                   TextField(
                       value = capacityValue,
                       onValueChange = onCapacityChange,
                       placeholder = {
                         Text(
                             "ex: 100",
-                            style = MaterialTheme.typography.bodySmall.copy(color = Color.Gray))
+                            style =
+                                MaterialTheme.typography.bodySmall.copy(
+                                    color = colorResource(id = R.color.gray)))
                       },
                       modifier = Modifier.fillMaxSize().testTag("capacity_input_field"),
                       colors =
                           TextFieldDefaults.colors(
-                              focusedContainerColor = Color(0xFF1C1C1C),
-                              unfocusedContainerColor = Color(0xFF1C1C1C),
+                              focusedContainerColor =
+                                  colorResource(id = R.color.eventform_field_bg),
+                              unfocusedContainerColor =
+                                  colorResource(id = R.color.eventform_field_bg),
                               focusedIndicatorColor = Color.Transparent,
                               unfocusedIndicatorColor = Color.Transparent,
-                              focusedTextColor = Color.White,
-                              unfocusedTextColor = Color.White,
+                              focusedTextColor = colorResource(id = R.color.white),
+                              unfocusedTextColor = colorResource(id = R.color.white),
                           ),
                       shape = RoundedCornerShape(10.dp),
                       textStyle = MaterialTheme.typography.bodySmall,
@@ -297,7 +337,7 @@ fun TicketsInputField(
               capacityError?.let {
                 Text(
                     text = it,
-                    color = Color.Red,
+                    color = colorResource(id = R.color.error_red),
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1)
               }
@@ -327,7 +367,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.TITLE.key]?.let {
       Text(
           text = it,
-          color = Color.Red,
+          color = colorResource(id = R.color.error_red),
           style = MaterialTheme.typography.bodySmall,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -341,7 +381,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.DESCRIPTION.key]?.let {
       Text(
           text = it,
-          color = Color.Red,
+          color = colorResource(id = R.color.error_red),
           style = MaterialTheme.typography.bodySmall,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -359,18 +399,21 @@ fun EventFormFields(
       fieldErrors[EventFormViewModel.ValidationError.START_TIME.key]?.let {
         Text(
             text = it,
-            color = Color.Red,
+            color = colorResource(id = R.color.error_red),
             style = MaterialTheme.typography.bodySmall,
             modifier = Modifier.padding(end = 12.dp))
       }
       fieldErrors[EventFormViewModel.ValidationError.END_TIME.key]?.let {
-        Text(text = it, color = Color.Red, style = MaterialTheme.typography.bodySmall)
+        Text(
+            text = it,
+            color = colorResource(id = R.color.error_red),
+            style = MaterialTheme.typography.bodySmall)
       }
     }
     fieldErrors[EventFormViewModel.ValidationError.TIME.key]?.let {
       Text(
           text = it,
-          color = Color.Red,
+          color = colorResource(id = R.color.error_red),
           style = MaterialTheme.typography.bodySmall,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -385,7 +428,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.DATE.key]?.let {
       Text(
           text = it,
-          color = Color.Red,
+          color = colorResource(id = R.color.error_red),
           style = MaterialTheme.typography.bodySmall,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -400,7 +443,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.LOCATION.key]?.let {
       Text(
           text = it,
-          color = Color.Red,
+          color = colorResource(id = R.color.error_red),
           style = MaterialTheme.typography.bodySmall,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }

--- a/app/src/main/java/ch/onepass/onepass/ui/eventform/createform/CreateEventForm.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventform/createform/CreateEventForm.kt
@@ -15,11 +15,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.onepass.onepass.R
 import ch.onepass.onepass.ui.eventform.EventFormFields
 import ch.onepass.onepass.ui.theme.DefaultBackground
 import ch.onepass.onepass.ui.theme.EventDateColor
+import com.mapbox.maps.extension.style.expressions.dsl.generated.color
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,10 +68,16 @@ fun CreateEventButton(onClick: () -> Unit, modifier: Modifier = Modifier) {
               .fillMaxWidth()
               .height(48.dp)
               .padding(start = 63.dp, top = 14.dp, end = 63.dp, bottom = 14.dp)
-              .background(color = Color(0xFF683F88), shape = RoundedCornerShape(size = 5.dp))
-              .background(color = Color(0x94333333), shape = RoundedCornerShape(size = 5.dp))
+              .background(
+                  color = colorResource(id = R.color.eventform_bg_purple),
+                  shape = RoundedCornerShape(size = 5.dp))
+              .background(
+                  color = colorResource(id = R.color.eventform_bg_overlay),
+                  shape = RoundedCornerShape(size = 5.dp))
               .border(
-                  width = 1.dp, color = Color(0xFF242424), shape = RoundedCornerShape(size = 5.dp)),
+                  width = 1.dp,
+                  color = colorResource(id = R.color.eventform_border),
+                  shape = RoundedCornerShape(size = 5.dp)),
       shape = RoundedCornerShape(5.dp),
       colors =
           ButtonDefaults.buttonColors(

--- a/app/src/main/java/ch/onepass/onepass/ui/eventform/editform/EditEventForm.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventform/editform/EditEventForm.kt
@@ -14,8 +14,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.onepass.onepass.R
 import ch.onepass.onepass.ui.eventform.EventFormFields
 import ch.onepass.onepass.ui.theme.DefaultBackground
 import ch.onepass.onepass.ui.theme.EventDateColor
@@ -52,12 +54,16 @@ fun UpdateEventButton(
               .fillMaxWidth()
               .height(48.dp)
               .padding(start = 63.dp, top = 14.dp, end = 63.dp, bottom = 14.dp)
-              .background(color = Color(0xFF683F88), shape = RoundedCornerShape(size = 5.dp))
-              .background(color = Color(0x94333333), shape = RoundedCornerShape(size = 5.dp)),
+              .background(
+                  color = colorResource(id = R.color.edit_update_btn_bg_primary),
+                  shape = RoundedCornerShape(size = 5.dp))
+              .background(
+                  color = colorResource(id = R.color.edit_update_btn_bg_overlay),
+                  shape = RoundedCornerShape(size = 5.dp)),
       shape = RoundedCornerShape(5.dp),
       colors =
           ButtonDefaults.buttonColors(
-              containerColor = Color.Transparent, contentColor = Color.White),
+              containerColor = Color.Transparent, contentColor = colorResource(id = R.color.white)),
       contentPadding = PaddingValues(0.dp),
       elevation = ButtonDefaults.buttonElevation(0.dp),
       enabled = !isLoading) {
@@ -67,7 +73,9 @@ fun UpdateEventButton(
             verticalAlignment = Alignment.CenterVertically) {
               if (isLoading) {
                 CircularProgressIndicator(
-                    modifier = Modifier.size(16.dp), color = Color.White, strokeWidth = 2.dp)
+                    modifier = Modifier.size(16.dp),
+                    color = colorResource(id = R.color.white),
+                    strokeWidth = 2.dp)
               } else {
                 Icon(
                     imageVector = Icons.Default.Edit,
@@ -122,7 +130,7 @@ fun EditEventForm(
       modifier = Modifier.testTag(EditEventFormTestTags.SCREEN),
       topBar = {
         TopAppBar(
-            title = { Text(text = "Edit Event", color = Color.White) },
+            title = { Text(text = "Edit Event", color = colorResource(id = R.color.white)) },
             navigationIcon = {
               IconButton(
                   onClick = onNavigateBack,
@@ -130,7 +138,7 @@ fun EditEventForm(
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
-                        tint = Color.White)
+                        tint = colorResource(id = R.color.white))
                   }
             },
             colors = TopAppBarDefaults.topAppBarColors(containerColor = DefaultBackground))
@@ -154,12 +162,12 @@ fun EditEventForm(
                     Text(
                         text = "Failed to load event",
                         style = MaterialTheme.typography.titleMedium,
-                        color = Color.White)
+                        color = colorResource(id = R.color.white))
                     Spacer(modifier = Modifier.height(16.dp))
                     Text(
                         text = (uiState as EditEventUiState.LoadError).message,
                         style = MaterialTheme.typography.bodyMedium,
-                        color = Color.Gray)
+                        color = colorResource(id = R.color.gray))
                     Spacer(modifier = Modifier.height(24.dp))
                     Button(
                         onClick = { viewModel.loadEvent(eventId) },

--- a/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
@@ -7,10 +7,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -94,7 +95,7 @@ fun FeedScreen(
           }
         }
       },
-      containerColor = Color(0xFF0A0A0A),
+      containerColor = colorResource(id = R.color.screen_background),
   ) { paddingValues ->
     Box(
         modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -159,7 +160,7 @@ private fun FeedTopBar(
 ) {
   Surface(
       modifier = modifier.fillMaxWidth().testTag(FeedScreenTestTags.FEED_TOP_BAR),
-      color = Color(0xFF0A0A0A),
+      color = colorResource(id = R.color.screen_background),
       tonalElevation = 0.dp,
   ) {
     Column(modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp)) {
@@ -173,14 +174,14 @@ private fun FeedTopBar(
               text = currentDateRange,
               style = MaterialTheme.typography.headlineLarge,
               fontWeight = FontWeight.Bold,
-              color = Color.White,
+              color = colorResource(id = R.color.white),
               letterSpacing = 2.sp,
               modifier = Modifier.testTag(FeedScreenTestTags.FEED_TITLE),
           )
           Text(
               text = currentLocation.uppercase(),
               style = MaterialTheme.typography.bodyMedium,
-              color = Color(0xFF9CA3AF),
+              color = colorResource(id = R.color.gray),
               modifier = Modifier.padding(top = 4.dp).testTag(FeedScreenTestTags.FEED_LOCATION),
           )
         }
@@ -196,7 +197,7 @@ private fun FeedTopBar(
             Icon(
                 painter = painterResource(id = R.drawable.filter_icon),
                 contentDescription = "Filter events",
-                tint = Color.White,
+                tint = colorResource(id = R.color.white),
                 modifier = Modifier.size(24.dp),
             )
           }
@@ -244,4 +245,87 @@ private fun EventListContent(
           }
         }
       }
+}
+
+/**
+ * Loading state indicator.
+ *
+ * @param modifier Optional modifier for the loading indicator.
+ */
+@Composable
+private fun LoadingState(modifier: Modifier = Modifier) {
+  CircularProgressIndicator(
+      modifier = modifier.testTag(FeedScreenTestTags.LOADING_INDICATOR),
+      color = colorResource(id = R.color.accent_purple),
+  )
+}
+
+/**
+ * Error state with retry button.
+ *
+ * @param error The error message string to display.
+ * @param onRetry Callback invoked when the retry button is clicked.
+ * @param modifier Optional modifier for the error state composable.
+ */
+@Composable
+private fun ErrorState(error: String, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+      modifier = modifier.fillMaxWidth().padding(32.dp).testTag(FeedScreenTestTags.ERROR_MESSAGE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+        text = "Oops!",
+        style = MaterialTheme.typography.headlineMedium,
+        fontWeight = FontWeight.Bold,
+        color = colorResource(id = R.color.white),
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = error,
+        style = MaterialTheme.typography.bodyMedium,
+        color = colorResource(id = R.color.gray),
+        textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(24.dp))
+    Button(
+        onClick = onRetry,
+        modifier = Modifier.testTag(FeedScreenTestTags.RETRY_BUTTON),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = colorResource(id = R.color.accent_purple),
+                contentColor = colorResource(id = R.color.white),
+            ),
+    ) {
+      Text(text = "Try Again", fontWeight = FontWeight.Medium)
+    }
+  }
+}
+
+/**
+ * Empty state when no events are available.
+ *
+ * @param modifier Optional modifier for the empty state composable.
+ */
+@Composable
+private fun EmptyFeedState(modifier: Modifier = Modifier) {
+  Column(
+      modifier = modifier.fillMaxWidth().padding(32.dp).testTag(FeedScreenTestTags.EMPTY_STATE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+        text = "No Events Found",
+        style = MaterialTheme.typography.headlineMedium,
+        fontWeight = FontWeight.Bold,
+        color = colorResource(id = R.color.white),
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+        text = "Check back later for new events in your area!",
+        style = MaterialTheme.typography.bodyMedium,
+        color = colorResource(id = R.color.gray),
+        textAlign = TextAlign.Center,
+    )
+  }
 }

--- a/app/src/main/java/ch/onepass/onepass/ui/myinvitations/MyInvitationsScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/myinvitations/MyInvitationsScreen.kt
@@ -12,11 +12,13 @@ import androidx.compose.material3.IconButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.onepass.onepass.R
 import ch.onepass.onepass.model.organization.*
 import ch.onepass.onepass.ui.components.common.EmptyState
 import ch.onepass.onepass.ui.components.common.ErrorState
@@ -144,7 +146,7 @@ internal fun MyInvitationsContent(
 
   Scaffold(
       modifier = modifier.fillMaxSize().testTag(MyInvitationsScreenTestTags.SCREEN),
-      containerColor = Color(0xFF0A0A0A),
+      containerColor = colorResource(id = R.color.screen_background),
       snackbarHost = {
         SnackbarHost(
             hostState = snackbarHostState,
@@ -152,8 +154,8 @@ internal fun MyInvitationsContent(
               Snackbar(
                   snackbarData = snackbarData,
                   modifier = Modifier.testTag(MyInvitationsScreenTestTags.SUCCESS_MESSAGE),
-                  containerColor = Color(0xFF4CAF50),
-                  contentColor = Color.White)
+                  containerColor = colorResource(id = R.color.myinvitations_success_green),
+                  contentColor = colorResource(id = R.color.white))
             })
       },
       topBar = {
@@ -163,17 +165,19 @@ internal fun MyInvitationsContent(
                   text = "My Invitations",
                   style = MaterialTheme.typography.headlineSmall,
                   fontWeight = FontWeight.Bold,
-                  color = Color.White)
+                  color = colorResource(id = R.color.white))
             },
             navigationIcon = {
               IconButton(onClick = onNavigateBack) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                     contentDescription = "Back",
-                    tint = Color.White)
+                    tint = colorResource(id = R.color.white))
               }
             },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color(0xFF0A0A0A)))
+            colors =
+                TopAppBarDefaults.topAppBarColors(
+                    containerColor = colorResource(id = R.color.screen_background)))
       }) { paddingValues ->
         Box(
             modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -203,6 +207,78 @@ internal fun MyInvitationsContent(
                 }
               }
             }
+      }
+}
+
+/** Displays a loading indicator while invitations are being fetched. */
+@Composable
+private fun LoadingState(modifier: Modifier = Modifier) {
+  CircularProgressIndicator(
+      modifier = modifier.testTag(MyInvitationsScreenTestTags.LOADING_INDICATOR),
+      color = colorResource(id = R.color.myinvitations_accent_purple))
+}
+
+/**
+ * Displays an error state with a message and retry button.
+ *
+ * @param error The error message to display.
+ * @param onRetry Callback invoked when the retry button is clicked.
+ * @param modifier Optional modifier for layout adjustments.
+ */
+@Composable
+private fun ErrorState(error: String, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+      modifier =
+          modifier.fillMaxWidth().padding(32.dp).testTag(MyInvitationsScreenTestTags.ERROR_MESSAGE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
+        Text(
+            text = "Oops!",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.white))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = error,
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.gray),
+            textAlign = TextAlign.Center)
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.testTag(MyInvitationsScreenTestTags.RETRY_BUTTON),
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = colorResource(id = R.color.myinvitations_accent_purple),
+                    contentColor = colorResource(id = R.color.white))) {
+              Text(text = "Try Again", fontWeight = FontWeight.Medium)
+            }
+      }
+}
+
+/**
+ * Displays an empty state when no invitations are available.
+ *
+ * @param modifier Optional modifier for layout adjustments.
+ */
+@Composable
+private fun EmptyState(modifier: Modifier = Modifier) {
+  Column(
+      modifier =
+          modifier.fillMaxWidth().padding(32.dp).testTag(MyInvitationsScreenTestTags.EMPTY_STATE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center) {
+        Text(
+            text = "No Invitations",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = colorResource(id = R.color.white))
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "You don't have any pending invitations at the moment.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.gray),
+            textAlign = TextAlign.Center)
       }
 }
 
@@ -270,7 +346,7 @@ private fun InvitationCard(
           Modifier.fillMaxWidth()
               .testTag(MyInvitationsScreenTestTags.getInvitationCardTag(invitation.id)),
       shape = RoundedCornerShape(16.dp),
-      color = Color(0xFF1B1B1B),
+      color = colorResource(id = R.color.myinvitations_card_background),
       tonalElevation = 0.dp) {
         Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
           // Organization name
@@ -278,7 +354,7 @@ private fun InvitationCard(
               text = organization?.name ?: invitation.orgId,
               style = MaterialTheme.typography.titleMedium,
               fontWeight = FontWeight.Bold,
-              color = Color.White,
+              color = colorResource(id = R.color.white),
               modifier = Modifier.testTag(MyInvitationsScreenTestTags.INVITATION_ORG_NAME))
 
           Spacer(modifier = Modifier.height(8.dp))
@@ -287,7 +363,7 @@ private fun InvitationCard(
           Text(
               text = "Role: ${invitation.role.name}",
               style = MaterialTheme.typography.bodyMedium,
-              color = Color(0xFF9CA3AF),
+              color = colorResource(id = R.color.gray),
               modifier = Modifier.testTag(MyInvitationsScreenTestTags.INVITATION_ROLE))
 
           Spacer(modifier = Modifier.height(16.dp))
@@ -304,7 +380,8 @@ private fun InvitationCard(
                             .testTag(MyInvitationsScreenTestTags.getRejectButtonTag(invitation.id)),
                     colors =
                         ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFF2A2A2A), contentColor = Color(0xFFD33A2C)),
+                            containerColor = colorResource(id = R.color.myinvitations_reject_bg),
+                            contentColor = colorResource(id = R.color.myinvitations_reject_red)),
                     shape = RoundedCornerShape(10.dp)) {
                       Text(text = "Reject", fontWeight = FontWeight.Medium)
                     }
@@ -317,7 +394,9 @@ private fun InvitationCard(
                             .testTag(MyInvitationsScreenTestTags.getAcceptButtonTag(invitation.id)),
                     colors =
                         ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFF9C6BFF), contentColor = Color.White),
+                            containerColor =
+                                colorResource(id = R.color.myinvitations_accent_purple),
+                            contentColor = colorResource(id = R.color.white)),
                     shape = RoundedCornerShape(10.dp)) {
                       Text(text = "Accept", fontWeight = FontWeight.Medium)
                     }

--- a/app/src/main/java/ch/onepass/onepass/ui/organization/OrganizationFeed.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/organization/OrganizationFeed.kt
@@ -12,10 +12,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.onepass.onepass.R
 import ch.onepass.onepass.model.organization.Organization
 import ch.onepass.onepass.ui.components.common.EmptyState
 import ch.onepass.onepass.ui.components.common.ErrorState
@@ -84,35 +87,36 @@ fun OrganizationFeedScaffold(
   Scaffold(
       modifier = modifier.fillMaxSize(),
       topBar = { OrganizationFeedTopBar(onNavigateBack = onNavigateBack) },
-      containerColor = Color(0xFF0A0A0A),
-  ) { paddingValues ->
-    Box(
-        modifier = Modifier.fillMaxSize().padding(paddingValues),
-        contentAlignment = Alignment.Center,
-    ) {
-      when {
-        isLoading && organizations.isEmpty() -> {
-          LoadingState(testTag = OrganizationFeedTestTags.LOADING_INDICATOR)
-        }
-        error != null && organizations.isEmpty() -> {
-          ErrorState(
-              error = error, onRetry = onRetry, testTag = OrganizationFeedTestTags.ERROR_MESSAGE)
-        }
-        !isLoading && organizations.isEmpty() -> {
-          EmptyState(
-              title = "No Organizations",
-              message = "You haven't joined any organizations yet.",
-              testTag = OrganizationFeedTestTags.EMPTY_STATE)
-        }
-        else -> {
-          OrganizationListContent(
-              organizations = organizations,
-              onOrganizationClick = onOrganizationClick,
-          )
+      containerColor = colorResource(id = R.color.screen_background)) { paddingValues ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(paddingValues),
+            contentAlignment = Alignment.Center,
+        ) {
+          when {
+            isLoading && organizations.isEmpty() -> {
+              LoadingState(testTag = OrganizationFeedTestTags.LOADING_INDICATOR)
+            }
+            error != null && organizations.isEmpty() -> {
+              ErrorState(
+                  error = error,
+                  onRetry = onRetry,
+                  testTag = OrganizationFeedTestTags.ERROR_MESSAGE)
+            }
+            !isLoading && organizations.isEmpty() -> {
+              EmptyState(
+                  title = "No Organizations",
+                  message = "You haven't joined any organizations yet.",
+                  testTag = OrganizationFeedTestTags.EMPTY_STATE)
+            }
+            else -> {
+              OrganizationListContent(
+                  organizations = organizations,
+                  onOrganizationClick = onOrganizationClick,
+              )
+            }
+          }
         }
       }
-    }
-  }
 }
 
 /** Top bar with title and back button. */
@@ -142,7 +146,9 @@ private fun OrganizationFeedTopBar(onNavigateBack: () -> Unit = {}, modifier: Mo
             letterSpacing = 2.sp,
             modifier = modifier.testTag(OrganizationFeedTestTags.ORGANIZATION_FEED_TITLE))
       },
-      colors = TopAppBarDefaults.centerAlignedTopAppBarColors(containerColor = Color(0xFF0A0A0A)))
+      colors =
+          TopAppBarDefaults.centerAlignedTopAppBarColors(
+              containerColor = colorResource(id = R.color.org_feed_top_bar)))
 }
 
 /** Organization list content with scrollable cards. */
@@ -164,5 +170,75 @@ private fun OrganizationListContent(
               Modifier.testTag(
                   OrganizationFeedTestTags.getTestTagForOrganizationItem(organization.id)))
     }
+  }
+}
+
+/** Loading state indicator. */
+@Composable
+private fun LoadingState(modifier: Modifier = Modifier) {
+  CircularProgressIndicator(
+      modifier = modifier.testTag(OrganizationFeedTestTags.LOADING_INDICATOR),
+      color = colorResource(id = R.color.accent_purple))
+}
+
+/** Error state with retry button. */
+@Composable
+private fun ErrorState(error: String, onRetry: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+      modifier =
+          modifier.fillMaxWidth().padding(32.dp).testTag(OrganizationFeedTestTags.ERROR_MESSAGE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+        text = "Oops!",
+        style = MaterialTheme.typography.headlineMedium,
+        fontWeight = FontWeight.Bold,
+        color = Color.White,
+    )
+    Spacer(modifier = modifier.height(8.dp))
+    Text(
+        text = error,
+        style = MaterialTheme.typography.bodyMedium,
+        color = colorResource(id = R.color.gray),
+        textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = modifier.height(24.dp))
+    Button(
+        onClick = onRetry,
+        modifier = modifier.testTag(OrganizationFeedTestTags.RETRY_BUTTON),
+        colors =
+            ButtonDefaults.buttonColors(
+                containerColor = colorResource(id = R.color.accent_purple),
+                contentColor = Color.White,
+            ),
+    ) {
+      Text(text = "Try Again", fontWeight = FontWeight.Medium)
+    }
+  }
+}
+
+/** Empty state when no organizations are available. */
+@Composable
+private fun EmptyOrganizationState(modifier: Modifier = Modifier) {
+  Column(
+      modifier =
+          modifier.fillMaxWidth().padding(32.dp).testTag(OrganizationFeedTestTags.EMPTY_STATE),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+  ) {
+    Text(
+        text = "No Organizations",
+        style = MaterialTheme.typography.headlineMedium,
+        fontWeight = FontWeight.Bold,
+        color = Color.White,
+    )
+    Spacer(modifier = modifier.height(8.dp))
+    Text(
+        text = "You haven't joined any organizations yet.",
+        style = MaterialTheme.typography.bodyMedium,
+        color = colorResource(id = R.color.gray),
+        textAlign = TextAlign.Center,
+    )
   }
 }

--- a/app/src/main/java/ch/onepass/onepass/ui/organization/OrganizerProfileScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/organization/OrganizerProfileScreen.kt
@@ -28,9 +28,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,6 +44,7 @@ import ch.onepass.onepass.ui.myevents.TicketStatus
 import ch.onepass.onepass.ui.theme.Typography
 import ch.onepass.onepass.ui.theme.White
 import com.google.firebase.Timestamp
+import com.mapbox.maps.extension.style.expressions.dsl.generated.color
 import kotlinx.coroutines.flow.collectLatest
 
 object OrganizerProfileTestTags {
@@ -81,7 +82,7 @@ fun OrganizerHeaderSection(
     modifier: Modifier = Modifier
 ) {
   Column(
-      verticalArrangement = Arrangement.spacedBy(-49.dp, Alignment.Top),
+      verticalArrangement = Arrangement.spacedBy((-49).dp, Alignment.Top),
       horizontalAlignment = Alignment.CenterHorizontally,
       modifier =
           modifier.width(392.dp).height(310.dp).testTag(OrganizerProfileTestTags.HEADER_SECTION)) {
@@ -103,7 +104,9 @@ fun OrganizerHeaderSection(
             modifier =
                 Modifier.width(98.dp)
                     .height(98.dp)
-                    .background(color = Color(0xFF262626), shape = RoundedCornerShape(50.dp))
+                    .background(
+                        color = colorResource(id = R.color.profile_accent),
+                        shape = RoundedCornerShape(50.dp))
                     .clip(RoundedCornerShape(50.dp))
                     .testTag(OrganizerProfileTestTags.PROFILE_IMAGE))
       }
@@ -124,7 +127,9 @@ fun OrganizerInfoSection(name: String, description: String, modifier: Modifier =
         Text(
             text = description,
             style =
-                Typography.bodySmall.copy(color = Color(0xFFC4C4C4), textAlign = TextAlign.Center),
+                Typography.bodySmall.copy(
+                    color = colorResource(id = R.color.profile_description_text),
+                    textAlign = TextAlign.Center),
             modifier =
                 Modifier.padding(horizontal = 20.dp)
                     .testTag(OrganizerProfileTestTags.DESCRIPTION_TEXT))
@@ -184,7 +189,9 @@ fun SocialMediaSection(
                     text = "Website",
                     style =
                         Typography.bodyMedium.copy(
-                            color = Color(0xFFA3A3A3), fontSize = 15.sp, lineHeight = 20.sp),
+                            color = colorResource(id = R.color.profile_website_text),
+                            fontSize = 15.sp,
+                            lineHeight = 20.sp),
                     modifier = Modifier.testTag(OrganizerProfileTestTags.WEBSITE_TEXT))
                 Image(
                     painter = painterResource(id = R.drawable.link_icon),
@@ -253,10 +260,11 @@ fun FollowSection(
                       Modifier.width(182.dp)
                           .height(42.dp)
                           .background(
-                              color = Color(0xFF4A3857), shape = RoundedCornerShape(size = 5.dp))
+                              color = colorResource(id = R.color.profile_follow_button_bg),
+                              shape = RoundedCornerShape(size = 5.dp))
                           .border(
                               width = 1.dp,
-                              color = Color(0xFF242424),
+                              color = colorResource(id = R.color.profile_follow_button_border),
                               shape = RoundedCornerShape(size = 5.dp))
                           .clickable { onFollowClick() }
                           .testTag(OrganizerProfileTestTags.FOLLOW_BUTTON)) {
@@ -287,7 +295,8 @@ fun FollowSection(
                       .testTag(OrganizerProfileTestTags.EDIT_ORGANIZATION_BUTTON),
               colors =
                   ButtonDefaults.buttonColors(
-                      containerColor = Color(0xFF4A3857), contentColor = White),
+                      containerColor = colorResource(id = R.color.profile_follow_button_bg),
+                      contentColor = White),
               shape = RoundedCornerShape(5.dp)) {
                 Text(text = "EDIT ORGANIZATION", style = Typography.titleMedium)
               }
@@ -305,8 +314,8 @@ fun Tab(
     testTag: String,
     modifier: Modifier = Modifier
 ) {
-  val selectedColor = Color(0xFF8F60A0)
-  val unselectedColor = Color(0xFF808080)
+  val selectedColor = colorResource(id = R.color.profile_tab_selected)
+  val unselectedColor = colorResource(id = R.color.profile_tab_unselected)
   val isSelected = selectedTab == tab
 
   Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = modifier) {
@@ -437,7 +446,7 @@ fun OrganizerProfileContent(
       horizontalAlignment = Alignment.CenterHorizontally,
       modifier =
           Modifier.fillMaxSize()
-              .background(color = Color(0xFF1A1A1A)) // TODO change to theme
+              .background(color = colorResource(id = R.color.profile_background))
               .verticalScroll(rememberScrollState())
               .padding(start = 10.dp, top = 20.dp, end = 10.dp, bottom = 12.dp)
               .testTag(OrganizerProfileTestTags.SCREEN)) {
@@ -494,7 +503,9 @@ fun PostsTabContent(modifier: Modifier = Modifier) {
       horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
             text = "No posts yet",
-            style = Typography.bodyMedium.copy(color = Color(0xFF808080)),
+            style =
+                Typography.bodyMedium.copy(
+                    color = colorResource(id = R.color.profile_tab_unselected)),
             modifier = Modifier.padding(32.dp))
       }
 }
@@ -520,7 +531,9 @@ fun UpcomingTabContent(
         if (events.isEmpty()) {
           Text(
               text = "No upcoming events",
-              style = Typography.bodyMedium.copy(color = Color(0xFF808080)),
+              style =
+                  Typography.bodyMedium.copy(
+                      color = colorResource(id = R.color.profile_tab_unselected)),
               modifier = Modifier.padding(32.dp))
         } else {
           events
@@ -555,7 +568,9 @@ fun PastTabContent(
         if (events.isEmpty()) {
           Text(
               text = "No past events",
-              style = Typography.bodyMedium.copy(color = Color(0xFF808080)),
+              style =
+                  Typography.bodyMedium.copy(
+                      color = colorResource(id = R.color.profile_tab_unselected)),
               modifier = Modifier.padding(32.dp))
         } else {
           events

--- a/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
@@ -41,6 +42,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import ch.onepass.onepass.R
 import kotlinx.coroutines.flow.collectLatest
 
 object ProfileTestTags {
@@ -62,16 +64,6 @@ object ProfileTestTags {
   const val SETTINGS_PAYMENTS = "profile_settings_payments"
   const val SETTINGS_HELP = "profile_settings_help"
   const val SETTINGS_SIGN_OUT = "profile_settings_sign_out"
-}
-
-// Centralized colors to avoid name clash with Material3.Surface
-private object ProfileColors {
-  val Background = Color(0xFF111111)
-  val Card = Color(0xFF1B1B1B)
-  val Accent = Color(0xFF9C6BFF)
-  val TextPrimary = Color.White
-  val TextSecondary = Color(0xFFB0B0B0)
-  val Divider = Color(0xFF2A2A2A)
 }
 
 @Composable
@@ -106,15 +98,15 @@ private fun ProfileContent(
     Box(
         modifier =
             Modifier.fillMaxSize()
-                .background(ProfileColors.Background)
+                .background(colorResource(id = R.color.profile_background))
                 .testTag(ProfileTestTags.LOADING),
         contentAlignment = Alignment.Center) {
-          CircularProgressIndicator(color = ProfileColors.Accent)
+          CircularProgressIndicator(color = colorResource(id = R.color.profile_accent))
         }
     return
   }
 
-  Scaffold(containerColor = ProfileColors.Background) { padding ->
+  Scaffold(containerColor = colorResource(id = R.color.profile_background)) { padding ->
     Column(
         modifier =
             Modifier.fillMaxSize()
@@ -132,7 +124,7 @@ private fun ProfileContent(
 
           Text(
               text = "ORGANIZER SETTINGS",
-              color = ProfileColors.TextSecondary,
+              color = colorResource(id = R.color.white),
               style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
               modifier = Modifier.testTag(ProfileTestTags.ORG_SECTION_TITLE))
 
@@ -144,38 +136,40 @@ private fun ProfileContent(
           Spacer(Modifier.height(12.dp))
 
           HorizontalDivider(
-              modifier = Modifier.alpha(0.2f), thickness = 1.dp, color = ProfileColors.Divider)
+              modifier = Modifier.alpha(0.2f),
+              thickness = 1.dp,
+              color = colorResource(id = R.color.profile_divider))
 
           Spacer(Modifier.height(8.dp))
 
           SettingsItem(
               icon = Icons.Outlined.Diversity3,
               title = "My Invitations",
-              titleColor = ProfileColors.TextPrimary,
+              titleColor = colorResource(id = R.color.white),
               onClick = onInvitations,
               testTag = ProfileTestTags.SETTINGS_INVITATIONS)
           SettingsItem(
               icon = Icons.Outlined.AccountCircle,
               title = "Account Settings",
-              titleColor = ProfileColors.TextPrimary,
+              titleColor = colorResource(id = R.color.white),
               onClick = onAccountSettings,
               testTag = ProfileTestTags.SETTINGS_ACCOUNT)
           SettingsItem(
               icon = Icons.Outlined.Settings,
               title = "Payment Methods",
-              titleColor = ProfileColors.TextPrimary,
+              titleColor = colorResource(id = R.color.white),
               onClick = onPaymentMethods,
               testTag = ProfileTestTags.SETTINGS_PAYMENTS)
           SettingsItem(
               icon = Icons.Outlined.Info,
               title = "Help & Support",
-              titleColor = ProfileColors.TextPrimary,
+              titleColor = colorResource(id = R.color.white),
               onClick = onHelp,
               testTag = ProfileTestTags.SETTINGS_HELP)
           SettingsItem(
               icon = Icons.AutoMirrored.Outlined.ExitToApp,
               title = "Sign Out",
-              titleColor = Color(0xFFD33A2C),
+              titleColor = colorResource(id = R.color.profile_sign_out_red),
               onClick = onSignOut,
               testTag = ProfileTestTags.SETTINGS_SIGN_OUT)
         }
@@ -213,7 +207,7 @@ private fun HeaderBlock(initials: String, name: String, email: String) {
             modifier =
                 Modifier.size(72.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF2B2B2B))
+                    .background(colorResource(id = R.color.profile_header_avatar_bg))
                     .testTag(ProfileTestTags.HEADER_INITIALS),
             contentAlignment = Alignment.Center) {
               Text(initials, color = Color.White, fontWeight = FontWeight.Bold)
@@ -224,7 +218,7 @@ private fun HeaderBlock(initials: String, name: String, email: String) {
         Column(Modifier.weight(1f)) {
           Text(
               text = name,
-              color = ProfileColors.TextPrimary,
+              color = colorResource(id = R.color.white),
               style =
                   MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.ExtraBold),
               maxLines = 1,
@@ -232,7 +226,7 @@ private fun HeaderBlock(initials: String, name: String, email: String) {
               modifier = Modifier.testTag(ProfileTestTags.HEADER_NAME))
           Text(
               text = email,
-              color = ProfileColors.TextSecondary,
+              color = colorResource(id = R.color.profile_text_secondary),
               style = MaterialTheme.typography.bodyMedium,
               modifier = Modifier.testTag(ProfileTestTags.HEADER_EMAIL))
         }
@@ -243,7 +237,7 @@ private fun HeaderBlock(initials: String, name: String, email: String) {
 @Composable
 private fun StatCard(value: Int, label: String, modifier: Modifier = Modifier) {
   Surface(
-      color = ProfileColors.Card,
+      color = colorResource(id = R.color.profile_card),
       shape = RoundedCornerShape(16.dp),
       tonalElevation = 0.dp,
       modifier = modifier.height(96.dp)) {
@@ -252,11 +246,11 @@ private fun StatCard(value: Int, label: String, modifier: Modifier = Modifier) {
             horizontalAlignment = Alignment.CenterHorizontally) {
               Text(
                   value.toString(),
-                  color = ProfileColors.Accent,
+                  color = colorResource(id = R.color.profile_accent),
                   style = MaterialTheme.typography.headlineSmall)
               Text(
                   label,
-                  color = ProfileColors.TextSecondary,
+                  color = colorResource(id = R.color.profile_text_secondary),
                   style = MaterialTheme.typography.bodyMedium)
             }
       }
@@ -265,11 +259,11 @@ private fun StatCard(value: Int, label: String, modifier: Modifier = Modifier) {
 /** Card for the organizer section. */
 @Composable
 private fun OrganizerCard(isOrganizer: Boolean, onOrganizationButton: () -> Unit) {
-  Surface(color = ProfileColors.Card, shape = RoundedCornerShape(16.dp)) {
+  Surface(color = colorResource(id = R.color.profile_card), shape = RoundedCornerShape(16.dp)) {
     Column(Modifier.padding(16.dp).testTag(ProfileTestTags.ORG_CARD)) {
       Text(
           text = if (isOrganizer) "Organization Management" else "Start Your Journey",
-          color = ProfileColors.TextPrimary,
+          color = colorResource(id = R.color.white),
           style = MaterialTheme.typography.titleMedium)
 
       Spacer(Modifier.height(8.dp))
@@ -278,7 +272,7 @@ private fun OrganizerCard(isOrganizer: Boolean, onOrganizationButton: () -> Unit
           text =
               if (isOrganizer) "Create and manage your organizations."
               else "Create epic events, build your community, and grow your audience.",
-          color = ProfileColors.TextSecondary,
+          color = colorResource(id = R.color.profile_text_secondary),
           style = MaterialTheme.typography.bodyMedium)
 
       Spacer(Modifier.height(16.dp))
@@ -287,7 +281,9 @@ private fun OrganizerCard(isOrganizer: Boolean, onOrganizationButton: () -> Unit
           onClick = onOrganizationButton,
           modifier = Modifier.fillMaxWidth().testTag(ProfileTestTags.ORG_CTA),
           shape = RoundedCornerShape(10.dp),
-          colors = ButtonDefaults.buttonColors(containerColor = ProfileColors.Accent)) {
+          colors =
+              ButtonDefaults.buttonColors(
+                  containerColor = colorResource(id = R.color.profile_accent))) {
             Icon(imageVector = Icons.Filled.Add, contentDescription = null, tint = Color.White)
             Spacer(Modifier.width(8.dp))
             Text(
@@ -319,7 +315,10 @@ private fun SettingsItem(
               .padding(horizontal = 6.dp)
               .testTag(testTag),
       verticalAlignment = Alignment.CenterVertically) {
-        Icon(icon, contentDescription = null, tint = Color(0xFF9B9B9B))
+        Icon(
+            icon,
+            contentDescription = null,
+            tint = colorResource(id = R.color.profile_settings_icon))
         Spacer(Modifier.width(16.dp))
         Text(title, color = titleColor, style = MaterialTheme.typography.bodyLarge)
       }

--- a/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import ch.onepass.onepass.R
 import ch.onepass.onepass.model.user.UserSearchType
@@ -81,7 +82,7 @@ fun StaffInvitationScreen(
             title = {
               Text(
                   text = "Add staff",
-                  color = Color.White,
+                  color = colorResource(R.color.white),
                   style = MaterialTheme.typography.titleLarge,
                   modifier = Modifier.testTag(StaffInvitationTestTags.TITLE))
             },
@@ -92,7 +93,7 @@ fun StaffInvitationScreen(
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                         contentDescription = "Back",
-                        tint = Color.White)
+                        tint = colorResource(R.color.white))
                   }
             },
             colors = TopAppBarDefaults.topAppBarColors(containerColor = DefaultBackground),
@@ -156,7 +157,7 @@ fun StaffInvitationScreen(
               uiState.errorMessage?.let { error ->
                 Text(
                     text = error,
-                    color = Color.Red,
+                    color = colorResource(id = R.color.error_red),
                     style = MaterialTheme.typography.bodySmall,
                     modifier =
                         Modifier.fillMaxWidth()
@@ -228,24 +229,39 @@ private fun SearchInputField(
       placeholder = {
         Text(
             text = placeholder,
-            style = MaterialTheme.typography.bodyMedium.copy(color = Color.Gray))
+            style = MaterialTheme.typography.bodyMedium.copy(color = colorResource(R.color.gray)))
       },
       modifier =
           modifier
               .fillMaxWidth()
-              .border(1.dp, Color(0xFF404040), RoundedCornerShape(10.dp))
+              .border(
+                  1.dp, colorResource(id = R.color.staff_search_border), RoundedCornerShape(10.dp))
               .heightIn(min = 50.dp)
               .testTag(StaffInvitationTestTags.SEARCH_FIELD),
       colors =
           TextFieldDefaults.colors(
-              focusedContainerColor = Color(0xFF1C1C1C),
-              unfocusedContainerColor = Color(0xFF1C1C1C),
+              focusedContainerColor = colorResource(R.color.staff_search_container),
+              unfocusedContainerColor = colorResource(R.color.staff_search_container),
               focusedIndicatorColor = Color.Transparent,
               unfocusedIndicatorColor = Color.Transparent,
-              focusedTextColor = Color.White,
-              unfocusedTextColor = Color.White,
+              focusedTextColor = colorResource(R.color.white),
+              unfocusedTextColor = colorResource(R.color.white),
           ),
       shape = RoundedCornerShape(10.dp),
       textStyle = MaterialTheme.typography.bodySmall,
       singleLine = true)
+}
+
+@Composable
+private fun EmptyState(message: String, modifier: Modifier = Modifier) {
+  Box(
+      modifier = modifier.testTag(StaffInvitationTestTags.EMPTY_STATE),
+      contentAlignment = Alignment.Center) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = colorResource(id = R.color.staff_tab_unselected),
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(horizontal = 32.dp))
+      }
 }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,6 +9,10 @@
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
+    <color name="gray">#9CA3AF</color>
+    <color name="accent_purple">#841DA4</color>
+    <color name="error_red">#FF0000</color>
+
     <!-- QR Code Component Gradient Colors -->
     <color name="qr_red">#EF4444</color>
     <color name="qr_pink">#C04875</color>
@@ -44,10 +48,89 @@
     <color name="on_surface">#FFFFFF</color>
     <color name="primary">#BB86FC</color>
 
-    <!-- Screen Background Colors (Figma: #1A1A1A) -->
+    <!-- Screen Background Colors -->
     <color name="screen_background">#1A1A1A</color>
     <color name="screen_surface">#1A1A1A</color>
 
     <!-- Staff List Item Background Color (Figma: #262626) -->
     <color name="staff_list_item_background">#262626</color>
+
+    <!-- Auth Screen Colors -->
+    <color name="blur_circle_top">#683F88</color>
+    <color name="blur_circle_bottom">#4B210A</color>
+
+    <!-- Heart Icon Colors -->
+    <color name="heart_liked">#E91E63</color>
+
+    <!-- Event Details Colors -->
+    <color name="event_back_section_bg">#1A1A1A</color>
+    <color name="event_buy_button_bg">#413857</color>
+    <color name="event_icon_gray">#A3A3A3</color>
+    <color name="event_border_gray">#242424</color>
+
+    <!-- Feed Screen Colors -->
+    <color name="feed_title_white">#FFFFFF</color>
+
+    <!-- Organisation Feed -->
+    <color name="org_feed_top_bar">#0A0A0A</color>
+
+    <!-- My Invitations Screen Colors -->
+    <color name="myinvitations_success_green">#4CAF50</color>
+    <color name="myinvitations_accent_purple">#9C6BFF</color>
+    <color name="myinvitations_card_background">#1B1B1B</color>
+    <color name="myinvitations_reject_bg">#2A2A2A</color>
+    <color name="myinvitations_reject_red">#D33A2C</color>
+
+    <!-- Event Form Colors -->
+    <color name="eventform_field_bg">#1C1C1C</color>
+    <color name="eventform_field_border">#404040</color>
+    <color name="eventform_timepicker_bg">#262626</color>
+    <color name="eventform_icon_gray">#808080</color>
+    <color name="eventform_placeholder_gray">#6C757D</color>
+    <color name="eventform_gray_overlay">#767680</color>
+    <color name="eventform_today_border">#9C6BFF</color>
+    <color name="eventform_range_bg">#9C6BFF4D</color>
+
+    <!-- Create Event form Colors -->
+    <color name="eventform_bg_purple">#683F88</color>
+    <color name="eventform_bg_overlay">#94333333</color>
+    <color name="eventform_border">#FF242424</color>
+
+    <!-- Edit Event form Colors -->
+    <color name="edit_update_btn_bg_primary">#683F88</color>
+    <color name="edit_update_btn_bg_overlay">#94333333</color>
+    <color name="staff_tab_unselected">#9CA3AF</color>
+    <color name="staff_search_border">#404040</color>
+    <color name="staff_search_container">#1C1C1C</color>
+
+    <!-- Profile Screen Colors -->
+    <color name="profile_card">#FF1B1B1B</color>
+    <color name="profile_text_secondary">#FFB0B0B0</color>
+    <color name="profile_divider">#FF2A2A2A</color>
+    <color name="profile_header_avatar_bg">#FF2B2B2B</color>
+    <color name="profile_sign_out_red">#FFD33A2C</color>
+    <color name="profile_settings_icon">#FF9B9B9B</color>
+    <color name="profile_background">#FF1A1A1A</color>
+    <color name="profile_accent">#FF262626</color>
+    <color name="profile_description_text">#FFC4C4C4</color>
+    <color name="profile_website_text">#FFA3A3A3</color>
+    <color name="profile_follow_button_bg">#FF4A3857</color>
+    <color name="profile_follow_button_border">#FF242424</color>
+    <color name="profile_tab_selected">#FF8F60A0</color>
+    <color name="profile_tab_unselected">#FF808080</color>
+
+    <!-- State Display Colors -->
+    <color name="state_display_text">#9CA3AF</color>
+
+    <!-- Date & Time Picker Color -->
+    <color name="time_picker_background">#767680</color>
+    <color name="date_picker_background">#1C1C1C</color>
+    <color name="date_picker_background_darker">#262626</color>
+    <color name="date_picker_border">#404040</color>
+    <color name="date_picker_text_secondary">#6C757D</color>
+
+    <!-- Location search Field Color -->
+    <color name="location_field_container">#1C1C1C</color>
+    <color name="location_field_border">#404040</color>
+    <color name="location_field_placeholder">#9CA3AF</color>
 </resources>


### PR DESCRIPTION
## Purpose of the Change
This PR updates multiple screens to align with the new **unified theme system** by removing all hardcoded color values and replacing them with centralized `colors.xml` resources or `MaterialTheme` values where applicable.  

The changes aim to:
- Ensure visual consistency across the app.  
- Simplify future theme updates.  
- Improve maintainability of UI code.

## Related Issues
Closes #333

## What Was Done
- Replaced all `Color(0xFF...)` hardcoded values in affected screens with references to `colorResource()` or `MaterialTheme` colors.  
- Added new color definitions in `colors.xml` to match existing UI elements.  
- Updated screens to consume theme-defined colors or centralized color resources.

## ⚠️ Note on Rebase with Main Branch
During the refactoring process, this branch was **rebased with `main`** to resolve merge conflicts.  
Some added or modified lines of code (LOC) are **not functional changes**, such as:

<img width="1308" height="444" alt="Screenshot 2025-11-21 at 01 14 34" src="https://github.com/user-attachments/assets/5af70cf0-0fe5-42a0-9700-b60706314271" />

## How to Test
1. Verify that all updated screens **compile without errors**.  
2. Confirm that **visual appearance remains consistent** with the previous design.  
3. Check that **no hardcoded color literals** remain in modified files.  
4. Validate that future theme changes correctly propagate across the updated screens.
