### PR TITLE
fix(profile): remove + from the My Orgs button if the user is an organizer

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
@@ -284,7 +284,8 @@ private fun OrganizerCard(isOrganizer: Boolean, onOrganizationButton: () -> Unit
           colors =
               ButtonDefaults.buttonColors(
                   containerColor = colorResource(id = R.color.profile_accent))) {
-            Icon(imageVector = Icons.Filled.Add, contentDescription = null, tint = Color.White)
+            if (!isOrganizer)
+                Icon(imageVector = Icons.Filled.Add, contentDescription = null, tint = Color.White)
             Spacer(Modifier.width(8.dp))
             Text(
                 text = if (isOrganizer) "My Organizations" else "Become an organizer",


### PR DESCRIPTION
**Description**
This PR fixes a minor bug ; “My Organizations” button incorrectly showed a + icon even though it only displays organizations rather than adding them.

**Related issue**
Closes #342 

**How to test**
Run the app :
- if the account is already an organizer, navigate to the profile screen
- otherwise, the button shows  "+ Become an Organizer" 
<img width="200" height="434" alt="Screenshot from 2025-11-24 16-24-07" src="https://github.com/user-attachments/assets/cad6c88d-a79b-4eb3-ac46-c7ec1cb3e117" />
<img width="200" height="434" alt="Screenshot from 2025-11-24 16-30-42" src="https://github.com/user-attachments/assets/73c826c4-3378-484b-a093-9b154de734a5" />


