### PR TITLE
feat(notification): add notifications viewmodel and unit tests

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/notification/NotificationViewModel.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/notification/NotificationViewModel.kt
@@ -57,10 +57,10 @@ class NotificationsViewModel(
       _uiState.value = _uiState.value.copy(isLoading = true)
       notificationRepository
           .getUserNotifications(userId)
-          .catch { e ->
+          .catch {
             _uiState.value =
                 _uiState.value.copy(
-                    isLoading = false, error = e.message ?: "Failed to load notifications")
+                    isLoading = false, error = it.message ?: "Failed to load notifications")
           }
           .collect { notifications ->
             _uiState.value =


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR introduces the ViewModel for the Notifications feature, as defined in sub-issue #360 .

It includes:
* `NotificationsViewModel` managing the UI state and interactions for the notifications screen.
* `NotificationsUiState` data class holding the screen state.
* Unit tests covering the ViewModel's functionality and error handling.

## Related issues
Closes #360 
Part of #357 

## How to test
1. Check out the branch.
2. Run the tests in `NotificationViewModelTest.kt` via Android Studio or `./gradlew test`.
3. Verify all tests pass.
4. Review the ViewModel implementation in `ui/notification/NotificationViewModel.kt` for correctness.

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.

**Related PRs in this series:**
- #364
- #365
- #366 *(this PR)*
- #367
- #368

The product obtained towards the end of this series of 5 PRs is shown below:

<table>
  <tr>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/aa858cf3-9dbe-4cb9-a833-0677b6403b16" alt="Notifications screen with items" width="300px">
      <br>
      <em>Notifications screen with items</em>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/b7029ffc-f5ea-4663-a740-a02634a64114" alt="Notifications screen with no items" width="300px">
      <br>
      <em>Notifications screen with no items</em>
    </td>
    <td align="center">
      <img src="https://github.com/user-attachments/assets/07fd6d67-f166-4aa2-b272-022ae599f553" alt="Updated Feed with bell icon" width="300px">
      <br>
      <em>Updated Feed with bell icon</em>
    </td>
  </tr>
</table>