### PR TITLE
fix(staff): prevent users from inviting themselves

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationViewModel.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationViewModel.kt
@@ -240,6 +240,10 @@ class StaffInvitationViewModel(
    * @return The result of the invitation attempt.
    */
   private suspend fun checkAndCreateInvitation(user: StaffSearchResult): InvitationResult {
+    if (user.id == currentUserId) {
+      return InvitationResult.Error("You cannot invite yourself.")
+    }
+
     // Check if user is already invited to this organization
     val existingInvitations = organizationRepository.getInvitationsByEmail(user.email).first()
 


### PR DESCRIPTION
# Description:
## Purpose of the change
This PR fixes a bug in the staff invitation system where users could invite themselves, which incorrectly assigned them the STAFF role rather than maintaining their OWNER role, as defined in issue #369 .

It includes:
* Validation check in `checkAndCreateInvitation` method to prevent self-invitation
* Clear error message "You cannot invite yourself." when self-invitation is attempted
* Maintains existing invitation logic for legitimate user invitations

## Related issues
Closes #369 

## How to test
1. Check out the branch.
2. Navigate to the staff management section of an organization you own.
3. Attempt to invite yourself by entering your own email address.
4. Verify that an error message is shown and the invitation is not created.
5. Verify that you can still successfully invite other users.
6. Run existing tests to ensure no regressions in invitation functionality.

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.