### PR TITLE
test(organizer): Add getUserById implementation to test fake

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/organizer/OrganizationFormViewModelTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/organizer/OrganizationFormViewModelTest.kt
@@ -352,6 +352,10 @@ class FakeUserRepository : UserRepository {
 
   override suspend fun updateLastLogin(uid: String) {}
 
+  override suspend fun getUserById(uid: String): Result<StaffSearchResult?> {
+    return Result.success(null)
+  }
+
   override suspend fun searchUsers(
       query: String,
       searchType: UserSearchType,


### PR DESCRIPTION
This commit updates the fake repository implementation within `OrganizationFormViewModelTest` to include an override for `getUserById`. This fixes compilation or runtime errors in tests caused by the missing method implementation.

- Implemented `getUserById` to return a success result with `null` in the test fake.

The reason for this issue is that both Rayane @RD418 and I were simultaneously refactoring the test, resulting in some new code being introduced without each other's knowledge during the process.
This is quite common during development and is easily fixable.

Nevertheless, I sincerely apologize for the inconvenience caused. I should have double-checked more carefully.