### PR TITLE
fix: restore pull-to-refresh feed behavior after PR #353 regression

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/feed/FeedScreenTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/feed/FeedScreenTest.kt
@@ -384,106 +384,111 @@ class FeedScreenTest {
     assertTrue(notificationClicked)
   }
 
-    @Test
-    fun feedScreen_pullToRefresh_triggersRefreshEvents() {
-        val events = listOf(testEvent1, testEvent2)
-        val mockRepository = MockEventRepository(events)
-        var refreshTriggered = false
-        val testViewModel =
-            object : FeedViewModel(mockRepository) {
-                override fun refreshEvents() {
-                    refreshTriggered = true
-                    super.refreshEvents()
-                }
-            }
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = testViewModel) } }
-        composeTestRule.waitForIdle()
-        // Simulate pull-to-refresh gesture
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.FEED_SCREEN).performTouchInput {
-            swipeDown(startY = centerY - 100.dp.toPx(), endY = centerY + 100.dp.toPx())
+  @Test
+  fun feedScreen_pullToRefresh_triggersRefreshEvents() {
+    val events = listOf(testEvent1, testEvent2)
+    val mockRepository = MockEventRepository(events)
+    var refreshTriggered = false
+    val testViewModel =
+        object : FeedViewModel(mockRepository) {
+          override fun refreshEvents() {
+            refreshTriggered = true
+            super.refreshEvents()
+          }
         }
-        composeTestRule.waitForIdle()
-        // Verify refresh was triggered
-        assert(refreshTriggered)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = testViewModel) } }
+    composeTestRule.waitForIdle()
+    // Simulate pull-to-refresh gesture
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.FEED_SCREEN).performTouchInput {
+      swipeDown(startY = centerY - 100.dp.toPx(), endY = centerY + 100.dp.toPx())
     }
-    @Test
-    fun feedScreen_showsRefreshingState_duringPullToRefresh() {
-        val events = listOf(testEvent1)
-        val mockRepository = MockEventRepository(events)
-        val viewModel = FeedViewModel(mockRepository)
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
-        composeTestRule.waitForIdle()
-        // Initially not refreshing
-        val initialState = viewModel.uiState.value
-        assert(!initialState.isRefreshing)
-        // Trigger refresh
-        viewModel.refreshEvents()
-        // Verify refreshing state is set
-        composeTestRule.waitForIdle()
-        val refreshingState = viewModel.uiState.value
-        assert(refreshingState.isRefreshing)
-    }
-    @Test
-    fun feedScreen_eventListShows_whenNotLoadingAndNotRefreshing() {
-        val events = listOf(testEvent1, testEvent2)
-        val mockRepository = MockEventRepository(events)
-        val viewModel = FeedViewModel(mockRepository)
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
-        composeTestRule.waitForIdle()
-        // Should show event list when not loading and not refreshing
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
-            .assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent2.eventId))
-            .assertIsDisplayed()
-    }
-    @Test
-    fun feedScreen_emptyState_showsOnlyWhenNotLoadingAndNotRefreshing() {
-        val mockRepository = MockEventRepository(emptyList())
-        val viewModel = FeedViewModel(mockRepository)
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
-        composeTestRule.waitForIdle()
-        // Should show empty state when not loading and not refreshing with no events
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EMPTY_STATE).assertIsDisplayed()
-        composeTestRule.onNodeWithText("No Events Found").assertIsDisplayed()
-    }
-    @Test
-    fun feedScreen_isLoadingMore_showsLoadingInEventList() {
-        val events = listOf(testEvent1, testEvent2)
-        val mockRepository = MockEventRepository(events)
-        val viewModel = FeedViewModel(mockRepository)
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
-        composeTestRule.waitForIdle()
-        viewModel.loadEvents()
-        composeTestRule.waitForIdle()
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
-            .assertIsDisplayed()
-    }
-    @Test
-    fun feedScreen_stateTransitions_correctlyDuringRefreshCycle() {
-        val events = listOf(testEvent1)
-        val mockRepository = MockEventRepository(events)
-        val viewModel = FeedViewModel(mockRepository)
-        composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
-        composeTestRule.waitForIdle()
-        // Initial state - events displayed
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
-        // Trigger refresh
-        viewModel.refreshEvents()
-        // During refresh - events should still be displayed (not loading state)
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
-            .assertIsDisplayed()
-        composeTestRule.waitForIdle()
-        // After refresh - events still displayed
-        composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
-        composeTestRule
-            .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
-            .assertIsDisplayed()
-    }
+    composeTestRule.waitForIdle()
+    // Verify refresh was triggered
+    assert(refreshTriggered)
+  }
+
+  @Test
+  fun feedScreen_showsRefreshingState_duringPullToRefresh() {
+    val events = listOf(testEvent1)
+    val mockRepository = MockEventRepository(events)
+    val viewModel = FeedViewModel(mockRepository)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
+    composeTestRule.waitForIdle()
+    // Initially not refreshing
+    val initialState = viewModel.uiState.value
+    assert(!initialState.isRefreshing)
+    // Trigger refresh
+    viewModel.refreshEvents()
+    // Verify refreshing state is set
+    composeTestRule.waitForIdle()
+    val refreshingState = viewModel.uiState.value
+    assert(refreshingState.isRefreshing)
+  }
+
+  @Test
+  fun feedScreen_eventListShows_whenNotLoadingAndNotRefreshing() {
+    val events = listOf(testEvent1, testEvent2)
+    val mockRepository = MockEventRepository(events)
+    val viewModel = FeedViewModel(mockRepository)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
+    composeTestRule.waitForIdle()
+    // Should show event list when not loading and not refreshing
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent2.eventId))
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun feedScreen_emptyState_showsOnlyWhenNotLoadingAndNotRefreshing() {
+    val mockRepository = MockEventRepository(emptyList())
+    val viewModel = FeedViewModel(mockRepository)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
+    composeTestRule.waitForIdle()
+    // Should show empty state when not loading and not refreshing with no events
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EMPTY_STATE).assertIsDisplayed()
+    composeTestRule.onNodeWithText("No Events Found").assertIsDisplayed()
+  }
+
+  @Test
+  fun feedScreen_isLoadingMore_showsLoadingInEventList() {
+    val events = listOf(testEvent1, testEvent2)
+    val mockRepository = MockEventRepository(events)
+    val viewModel = FeedViewModel(mockRepository)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
+    composeTestRule.waitForIdle()
+    viewModel.loadEvents()
+    composeTestRule.waitForIdle()
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
+        .assertIsDisplayed()
+  }
+
+  @Test
+  fun feedScreen_stateTransitions_correctlyDuringRefreshCycle() {
+    val events = listOf(testEvent1)
+    val mockRepository = MockEventRepository(events)
+    val viewModel = FeedViewModel(mockRepository)
+    composeTestRule.setContent { OnePassTheme { FeedScreen(viewModel = viewModel) } }
+    composeTestRule.waitForIdle()
+    // Initial state - events displayed
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
+    // Trigger refresh
+    viewModel.refreshEvents()
+    // During refresh - events should still be displayed (not loading state)
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
+        .assertIsDisplayed()
+    composeTestRule.waitForIdle()
+    // After refresh - events still displayed
+    composeTestRule.onNodeWithTag(FeedScreenTestTags.EVENT_LIST).assertIsDisplayed()
+    composeTestRule
+        .onNodeWithTag(FeedScreenTestTags.getTestTagForEventItem(testEvent1.eventId))
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
@@ -104,33 +104,33 @@ fun FeedScreen(
       },
       containerColor = colorResource(id = R.color.screen_background),
   ) { paddingValues ->
-      val pullState = rememberPullToRefreshState()
-      PullToRefreshBox(
-          isRefreshing = uiState.isRefreshing,
-          onRefresh = viewModel::refreshEvents,
-          state = pullState,
-              modifier = Modifier.fillMaxSize().padding(paddingValues),
-          ) {
+    val pullState = rememberPullToRefreshState()
+    PullToRefreshBox(
+        isRefreshing = uiState.isRefreshing,
+        onRefresh = viewModel::refreshEvents,
+        state = pullState,
+        modifier = Modifier.fillMaxSize().padding(paddingValues),
+    ) {
       when {
-          // Initial loading state (only show when not refreshing to avoid duplicate indicators)
-          uiState.isLoading && uiState.events.isEmpty() && !uiState.isRefreshing -> {
+        // Initial loading state (only show when not refreshing to avoid duplicate indicators)
+        uiState.isLoading && uiState.events.isEmpty() && !uiState.isRefreshing -> {
           LoadingState(testTag = FeedScreenTestTags.LOADING_INDICATOR)
         }
-          // Error state (only show when we have no events to display)
+        // Error state (only show when we have no events to display)
         uiState.error != null && uiState.events.isEmpty() -> {
           ErrorState(
               error = uiState.error!!,
               onRetry = { viewModel.refreshEvents() },
               testTag = FeedScreenTestTags.ERROR_MESSAGE)
         }
-          // Empty state (only when not loading/refreshing and truly empty)
-          !uiState.isLoading && !uiState.isRefreshing && uiState.events.isEmpty() -> {
+        // Empty state (only when not loading/refreshing and truly empty)
+        !uiState.isLoading && !uiState.isRefreshing && uiState.events.isEmpty() -> {
           EmptyState(
               title = "No Events Found",
               message = "Check back later for new events in your area!",
               testTag = FeedScreenTestTags.EMPTY_STATE)
         }
-          // Normal content display (handles both initial load and refresh scenarios)
+        // Normal content display (handles both initial load and refresh scenarios)
         else -> {
           EventListContent(
               events = uiState.events,


### PR DESCRIPTION
# Description

## Purpose of the change
This PR restores the **pull-to-refresh functionality** on the feed screen that was inadvertently deleted when PR #353 was merged. This feature, originally implemented in PR #332, allows users to refresh feed content by pulling down from the top of the feed, providing an intuitive manual refresh mechanism.

The restoration re-implements the pull-to-refresh gesture handling with proper visual feedback and state management to ensure users can easily retrieve the latest feed content without navigating away from the screen.

## Related issues
Closes #424

## How to test
* Check out the branch.  
* Run the app and navigate to the feed screen.  
* Verify that:
  - Scrolling to the top and pulling down triggers a refresh.
  - A loading indicator appears while new events are being fetched.
  - The feed updates with the latest events in correct order after refresh.
  - Pull-to-refresh does not interfere with normal scrolling behavior.
* Run the unit tests to confirm: `FeedViewModelTest.kt` and `FeedScreenTest.kt`.

**Note:** I wanted to include a screenshot of the loading indicator, but it's difficult to capture since the refresh animation completes very quickly during normal operation.

**Note:** An LLM was used for the sole and exclusive purpose of improving the clarity and formatting of the PR description.