### PR TITLE
feat: add pending invitations badge to Profile screen

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/profile/ProfileScreenComposeTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/profile/ProfileScreenComposeTest.kt
@@ -98,4 +98,61 @@ class ProfileScreenComposeTest {
     compose.onNodeWithTag(ProfileTestTags.HEADER_AVATAR).assertDoesNotExist()
     compose.onNodeWithText("WS").assertIsDisplayed()
   }
+
+  @Test
+  fun invitationsBadge_notShownWhenCountIsZero() {
+    val state =
+        ProfileUiState(
+            displayName = "Test User",
+            email = "test@email.com",
+            initials = "TU",
+            pendingInvitations = 0, // Zero invitations
+            loading = false)
+    val fakeVm = FakeProfileViewModel(state)
+
+    compose.setContent { ProfileScreen(viewModel = fakeVm, onEffect = {}) }
+
+    // Badge should not exist when count is 0
+    compose.onNodeWithTag(ProfileTestTags.SETTINGS_INVITATIONS_BADGE).assertDoesNotExist()
+  }
+
+  @Test
+  fun invitationsBadge_shownWhenCountIsGreaterThanZero() {
+    val state =
+        ProfileUiState(
+            displayName = "Test User",
+            email = "test@email.com",
+            initials = "TU",
+            pendingInvitations = 3, // 3 pending invitations
+            loading = false)
+    val fakeVm = FakeProfileViewModel(state)
+
+    compose.setContent { ProfileScreen(viewModel = fakeVm, onEffect = {}) }
+
+    // Badge should be displayed - use useUnmergedTree = true
+    compose
+        .onNodeWithTag(ProfileTestTags.SETTINGS_INVITATIONS_BADGE, useUnmergedTree = true)
+        .assertIsDisplayed()
+    // Badge should show the correct count
+    compose.onNodeWithText("3", useUnmergedTree = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun invitationsBadge_displaysCorrectCount() {
+    val state =
+        ProfileUiState(
+            displayName = "Test User",
+            email = "test@email.com",
+            initials = "TU",
+            pendingInvitations = 15, // 15 pending invitations
+            loading = false)
+    val fakeVm = FakeProfileViewModel(state)
+
+    compose.setContent { ProfileScreen(viewModel = fakeVm, onEffect = {}) }
+
+    compose
+        .onNodeWithTag(ProfileTestTags.SETTINGS_INVITATIONS_BADGE, useUnmergedTree = true)
+        .assertIsDisplayed()
+    compose.onNodeWithText("15", useUnmergedTree = true).assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import ch.onepass.onepass.R
+import ch.onepass.onepass.ui.theme.PurplePrimary
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import kotlinx.coroutines.flow.collectLatest
@@ -66,6 +67,7 @@ object ProfileTestTags {
   const val ORG_CTA = "profile_org_cta"
   const val SETTINGS_ACCOUNT = "profile_settings_account"
   const val SETTINGS_INVITATIONS = "profile_settings_invitations"
+  const val SETTINGS_INVITATIONS_BADGE = "profile_settings_invitations_badge"
   const val SETTINGS_PAYMENTS = "profile_settings_payments"
   const val SETTINGS_HELP = "profile_settings_help"
   const val SETTINGS_SIGN_OUT = "profile_settings_sign_out"
@@ -156,7 +158,8 @@ private fun ProfileContent(
               title = "My Invitations",
               titleColor = colorResource(id = R.color.white),
               onClick = onInvitations,
-              testTag = ProfileTestTags.SETTINGS_INVITATIONS)
+              testTag = ProfileTestTags.SETTINGS_INVITATIONS,
+              badgeCount = state.pendingInvitations)
           SettingsItem(
               icon = Icons.Outlined.AccountCircle,
               title = "Account Settings",
@@ -324,7 +327,25 @@ private fun OrganizerCard(isOrganizer: Boolean, onOrganizationButton: () -> Unit
     }
   }
 }
-
+/** Displays a circular badge with a count, styled in purple. Only displays when count > 0. */
+@Composable
+private fun BadgeCount(count: Int, modifier: Modifier = Modifier) {
+  if (count > 0) {
+    Box(
+        modifier =
+            modifier
+                .background(color = PurplePrimary, shape = CircleShape)
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .testTag(ProfileTestTags.SETTINGS_INVITATIONS_BADGE),
+        contentAlignment = Alignment.Center) {
+          Text(
+              text = count.toString(),
+              color = Color.White,
+              style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+              maxLines = 1)
+        }
+  }
+}
 /** List item used for settings actions. */
 @Composable
 private fun SettingsItem(
@@ -332,14 +353,15 @@ private fun SettingsItem(
     title: String,
     titleColor: Color,
     onClick: () -> Unit,
-    testTag: String
+    testTag: String,
+    badgeCount: Int = 0
 ) {
   Row(
       modifier =
           Modifier.fillMaxWidth()
               .heightIn(min = 52.dp)
               .clickable(onClick = onClick)
-              .semantics {
+              .semantics(mergeDescendants = false) {
                 role = Role.Button
                 this.contentDescription = title
               }
@@ -351,6 +373,13 @@ private fun SettingsItem(
             contentDescription = null,
             tint = colorResource(id = R.color.profile_settings_icon))
         Spacer(Modifier.width(16.dp))
-        Text(title, color = titleColor, style = MaterialTheme.typography.bodyLarge)
+        Text(
+            title,
+            color = titleColor,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f))
+        if (badgeCount > 0) {
+          BadgeCount(count = badgeCount)
+        }
       }
 }


### PR DESCRIPTION
## Summary
This PR adds a visual badge indicator to the "My Invitations" button on the Profile screen, displaying the count of pending organization invitations. The badge updates in real-time via Firestore and provides users with immediate visibility of pending invitations without navigating to the invitations screen.

## Related issues
Closes #468

## Key features
- Display purple badge with count on "My Invitations" button
- Real-time updates via Firestore Flow observing pending invitations
- Badge automatically hidden when count is zero
- Query invitations by user email filtered by PENDING status
- Accessible badge component with dedicated test tags

## Tests
**UI Tests:**
- Badge not shown when count is zero
- Badge displayed when count is greater than zero
- Badge shows correct count value
- Semantic tree accessibility for nested components
- All existing tests passing

## How to test
1. Run the emulator
2. Run `ProfileScreenComposeTest` to verify badge behavior
3. Manually verify badge appears with correct count on Profile screen (invite yourself from another account multiple times)
4. Create/delete invitations to test real-time updates

<img width="443" height="475" alt="Screenshot from 2025-12-11 13-17-27" src="https://github.com/user-attachments/assets/1d0d321c-05b1-47f8-aa9c-d12fbf53ec16" />

