### PR TITLE
fix(ui): change Error color calls by colorScheme.error

### DIFF
--- a/app/src/main/java/ch/onepass/onepass/ui/components/forms/FormFields.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/components/forms/FormFields.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import ch.onepass.onepass.ui.theme.Error
 
 /**
  * Reusable text field component for the form.
@@ -69,7 +68,9 @@ fun FormTextField(
         keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
         singleLine = maxLines == 1,
         maxLines = maxLines)
-    errorMessage?.let { Text(it, color = Error, style = MaterialTheme.typography.bodySmall) }
+    errorMessage?.let {
+      Text(it, color = colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    }
     Spacer(Modifier.height(16.dp))
   }
 }
@@ -160,7 +161,9 @@ fun PrefixPhoneRow(
           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Phone))
     }
 
-    prefixError?.let { Text(it, color = Error, style = MaterialTheme.typography.bodySmall) }
+    prefixError?.let {
+      Text(it, color = colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    }
 
     Spacer(Modifier.height(16.dp))
   }

--- a/app/src/main/java/ch/onepass/onepass/ui/eventform/EventFormFields.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/eventform/EventFormFields.kt
@@ -42,7 +42,6 @@ import ch.onepass.onepass.ui.components.buttons.UploadImageButton
 import ch.onepass.onepass.ui.components.forms.DatePickerField
 import ch.onepass.onepass.ui.components.forms.LocationSearchField
 import ch.onepass.onepass.ui.components.forms.TimePickerField
-import ch.onepass.onepass.ui.theme.Error
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -291,7 +290,7 @@ fun TicketsInputField(
               priceError?.let {
                 Text(
                     text = it,
-                    color = Error,
+                    color = colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium,
                     maxLines = 1)
               }
@@ -340,7 +339,7 @@ fun TicketsInputField(
               capacityError?.let {
                 Text(
                     text = it,
-                    color = Error,
+                    color = colorScheme.error,
                     style = MaterialTheme.typography.bodyMedium,
                     maxLines = 1)
               }
@@ -438,7 +437,7 @@ fun FieldLabelWithCounter(
             style =
                 MaterialTheme.typography.bodyMedium.copy(
                     color =
-                        if (isError || currentLength >= maxLength) Error
+                        if (isError || currentLength >= maxLength) colorScheme.error
                         else colorScheme.onSurface))
       }
 }
@@ -473,7 +472,8 @@ fun CompactFieldLabel(
             style =
                 MaterialTheme.typography.labelSmall.copy(
                     color =
-                        if (isError || currentLength >= maxLength) Error else colorScheme.onSurface,
+                        if (isError || currentLength >= maxLength) colorScheme.error
+                        else colorScheme.onSurface,
                     fontSize = 10.sp))
       }
 }
@@ -498,7 +498,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.TITLE.key]?.let {
       Text(
           text = it,
-          color = Error,
+          color = colorScheme.error,
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -512,7 +512,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.DESCRIPTION.key]?.let {
       Text(
           text = it,
-          color = Error,
+          color = colorScheme.error,
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -530,18 +530,18 @@ fun EventFormFields(
       fieldErrors[EventFormViewModel.ValidationError.START_TIME.key]?.let {
         Text(
             text = it,
-            color = Error,
+            color = colorScheme.error,
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.padding(end = 12.dp))
       }
       fieldErrors[EventFormViewModel.ValidationError.END_TIME.key]?.let {
-        Text(text = it, color = Error, style = MaterialTheme.typography.bodyMedium)
+        Text(text = it, color = colorScheme.error, style = MaterialTheme.typography.bodyMedium)
       }
     }
     fieldErrors[EventFormViewModel.ValidationError.TIME.key]?.let {
       Text(
           text = it,
-          color = Error,
+          color = colorScheme.error,
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -556,7 +556,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.DATE.key]?.let {
       Text(
           text = it,
-          color = Error,
+          color = colorScheme.error,
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }
@@ -571,7 +571,7 @@ fun EventFormFields(
     fieldErrors[EventFormViewModel.ValidationError.LOCATION.key]?.let {
       Text(
           text = it,
-          color = Error,
+          color = colorScheme.error,
           style = MaterialTheme.typography.bodyMedium,
           modifier = Modifier.padding(start = 8.dp, top = 4.dp))
     }

--- a/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/feed/FeedScreen.kt
@@ -61,7 +61,6 @@ import ch.onepass.onepass.ui.feed.FeedScreenTestTags.getTestTagForSearchEvent
 import ch.onepass.onepass.ui.feed.FeedScreenTestTags.getTestTagForSearchOrg
 import ch.onepass.onepass.ui.feed.FeedScreenTestTags.getTestTagForSearchUser
 import ch.onepass.onepass.ui.organization.OrganizationCard
-import ch.onepass.onepass.ui.theme.Error
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -323,7 +322,7 @@ private fun FeedContentStateSwitcher(
               item {
                 Text(
                     text = "Error: ${searchState.error}",
-                    color = Error,
+                    color = colorScheme.error,
                     modifier = Modifier.padding(16.dp).testTag(FeedScreenTestTags.ERROR_MESSAGE))
               }
             }

--- a/app/src/main/java/ch/onepass/onepass/ui/map/MapScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/map/MapScreen.kt
@@ -39,7 +39,6 @@ import ch.onepass.onepass.ui.event.EventCardViewModel
 import ch.onepass.onepass.ui.eventfilters.ActiveFiltersBar
 import ch.onepass.onepass.ui.eventfilters.EventFilterViewModel
 import ch.onepass.onepass.ui.eventfilters.FilterDialog
-import ch.onepass.onepass.ui.theme.Error
 import com.mapbox.maps.MapView
 import com.mapbox.maps.extension.compose.MapEffect
 import com.mapbox.maps.extension.compose.MapboxMap
@@ -156,7 +155,7 @@ fun MapScreen(
           Box(
               modifier =
                   Modifier.size(TrackingIndicatorDimensions.SIZE)
-                      .background(Error, CircleShape)
+                      .background(colorScheme.error, CircleShape)
                       .border(
                           TrackingIndicatorDimensions.BORDER_WIDTH,
                           colorScheme.surface,

--- a/app/src/main/java/ch/onepass/onepass/ui/myevents/MyEventsScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/myevents/MyEventsScreen.kt
@@ -65,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import ch.onepass.onepass.model.payment.StripePaymentHelper
 import ch.onepass.onepass.ui.components.common.EmptyState
 import ch.onepass.onepass.ui.payment.LocalPaymentSheet
-import ch.onepass.onepass.ui.theme.Error
 import ch.onepass.onepass.ui.theme.MarcFontFamily
 import com.google.firebase.auth.FirebaseAuth
 
@@ -246,7 +245,7 @@ fun MyEventsContent(userQrData: String, viewModel: MyEventsViewModel) {
             Snackbar(
                 snackbarData = data,
                 containerColor = colorScheme.surface,
-                contentColor = Error,
+                contentColor = colorScheme.error,
                 shape = RoundedCornerShape(12.dp))
           }
     }
@@ -604,7 +603,8 @@ private fun ListedTicketCard(
               modifier = Modifier.fillMaxWidth().height(44.dp),
               colors =
                   ButtonDefaults.buttonColors(
-                      containerColor = Error.copy(alpha = 0.1f), contentColor = Error),
+                      containerColor = colorScheme.error.copy(alpha = 0.1f),
+                      contentColor = colorScheme.error),
               shape = RoundedCornerShape(12.dp)) {
                 Text(
                     text = "Cancel Listing",
@@ -635,7 +635,7 @@ private fun ListedTicketCard(
                 showCancelDialog = false
                 onCancelListing()
               }) {
-                Text(text = "Cancel Listing", color = Error)
+                Text(text = "Cancel Listing", color = colorScheme.error)
               }
         },
         dismissButton = {

--- a/app/src/main/java/ch/onepass/onepass/ui/myevents/SellTicketDialog.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/myevents/SellTicketDialog.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import ch.onepass.onepass.ui.theme.Error
 import ch.onepass.onepass.ui.theme.MarcFontFamily
 import ch.onepass.onepass.utils.FormatUtils.formatPriceCompact
 
@@ -128,12 +127,12 @@ fun SellTicketDialog(
                     modifier =
                         Modifier.fillMaxWidth()
                             .clip(RoundedCornerShape(8.dp))
-                            .background(Error)
+                            .background(colorScheme.error)
                             .padding(12.dp)) {
                       Text(
                           text = errorMessage,
                           style = MaterialTheme.typography.bodySmall,
-                          color = Error,
+                          color = colorScheme.error,
                           modifier = Modifier.testTag(MyEventsTestTags.SELL_DIALOG_ERROR))
                     }
               }

--- a/app/src/main/java/ch/onepass/onepass/ui/myinvitations/MyInvitationsScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/myinvitations/MyInvitationsScreen.kt
@@ -45,7 +45,6 @@ import ch.onepass.onepass.ui.components.common.ErrorState
 import ch.onepass.onepass.ui.components.common.LoadingState
 import ch.onepass.onepass.ui.navigation.BackNavigationScaffold
 import ch.onepass.onepass.ui.navigation.TopBarConfig
-import ch.onepass.onepass.ui.theme.Error
 import kotlinx.coroutines.flow.first
 
 /**
@@ -301,7 +300,7 @@ private fun InvitationCard(
                             .testTag(MyInvitationsScreenTestTags.getRejectButtonTag(invitation.id)),
                     colors =
                         ButtonDefaults.buttonColors(
-                            containerColor = colorScheme.surface, contentColor = Error),
+                            containerColor = colorScheme.surface, contentColor = colorScheme.error),
                     shape = RoundedCornerShape(10.dp)) {
                       Text(text = "Reject", fontWeight = FontWeight.Medium)
                     }

--- a/app/src/main/java/ch/onepass/onepass/ui/notification/NotificationItem.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/notification/NotificationItem.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import ch.onepass.onepass.model.notification.Notification
-import ch.onepass.onepass.ui.theme.Error
 import ch.onepass.onepass.utils.DateTimeUtils.formatNotificationDate
 
 /**
@@ -82,7 +81,7 @@ fun NotificationItem(notification: Notification, onClick: () -> Unit, onDelete: 
                 Icon(
                     imageVector = Icons.Default.Delete,
                     contentDescription = "Delete notification",
-                    tint = Error)
+                    tint = colorScheme.error)
               }
             }
       }

--- a/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/profile/ProfileScreen.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import ch.onepass.onepass.ui.theme.Error
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import kotlinx.coroutines.flow.collectLatest
@@ -189,7 +188,7 @@ private fun ProfileContent(
           SettingsItem(
               icon = Icons.AutoMirrored.Outlined.ExitToApp,
               title = "Sign Out",
-              titleColor = Error,
+              titleColor = colorScheme.error,
               onClick = onSignOut,
               testTag = ProfileTestTags.SETTINGS_SIGN_OUT)
         }

--- a/app/src/main/java/ch/onepass/onepass/ui/scan/ScanScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/scan/ScanScreen.kt
@@ -256,7 +256,7 @@ fun ScanContent(viewModel: ScannerViewModel, onNavigateBack: () -> Unit = {}) {
           Icon(
               imageVector = Icons.Outlined.Error,
               contentDescription = null,
-              tint = ch.onepass.onepass.ui.theme.Error)
+              tint = colorScheme.error)
         },
         title = {
           Text(
@@ -275,8 +275,7 @@ fun ScanContent(viewModel: ScannerViewModel, onNavigateBack: () -> Unit = {}) {
                 showSessionExpiredDialog = false
                 onNavigateBack() // Go back, auth system will handle redirect to login
               },
-              colors =
-                  ButtonDefaults.buttonColors(containerColor = ch.onepass.onepass.ui.theme.Error)) {
+              colors = ButtonDefaults.buttonColors(containerColor = colorScheme.error)) {
                 Text("OK")
               }
         },
@@ -523,7 +522,7 @@ private fun BoxScope.ScanningFrame(uiState: ScannerUiState) {
           targetValue =
               when (uiState.status) {
                 ScannerUiState.Status.ACCEPTED -> Success
-                ScannerUiState.Status.REJECTED -> ch.onepass.onepass.ui.theme.Error
+                ScannerUiState.Status.REJECTED -> colorScheme.error
                 ScannerUiState.Status.ERROR -> Warning
                 else -> colorScheme.primary
               },
@@ -697,8 +696,7 @@ private fun BoxScope.ScanHud(uiState: ScannerUiState) {
           targetValue =
               when (uiState.status) {
                 ScannerUiState.Status.ACCEPTED -> Success.copy(alpha = 0.15f)
-                ScannerUiState.Status.REJECTED ->
-                    ch.onepass.onepass.ui.theme.Error.copy(alpha = 0.15f)
+                ScannerUiState.Status.REJECTED -> colorScheme.error.copy(alpha = 0.15f)
                 ScannerUiState.Status.ERROR -> Warning.copy(alpha = 0.15f)
                 else -> Color.Transparent
               },
@@ -900,7 +898,7 @@ internal fun PreviewHudContainer(state: ScannerUiState) {
                     color =
                         when (state.status) {
                           ScannerUiState.Status.ACCEPTED -> Success
-                          ScannerUiState.Status.REJECTED -> ch.onepass.onepass.ui.theme.Error
+                          ScannerUiState.Status.REJECTED -> colorScheme.error
                           ScannerUiState.Status.ERROR -> Warning
                           else -> colorScheme.primary
                         },

--- a/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationScreen.kt
+++ b/app/src/main/java/ch/onepass/onepass/ui/staff/StaffInvitationScreen.kt
@@ -58,7 +58,6 @@ import ch.onepass.onepass.ui.components.common.EmptyState
 import ch.onepass.onepass.ui.components.common.LoadingState
 import ch.onepass.onepass.ui.navigation.BackNavigationScaffold
 import ch.onepass.onepass.ui.navigation.TopBarConfig
-import ch.onepass.onepass.ui.theme.Error
 import kotlinx.coroutines.launch
 
 object StaffInvitationTestTags {
@@ -174,7 +173,7 @@ fun StaffInvitationScreen(
               uiState.errorMessage?.let { error ->
                 Text(
                     text = error,
-                    color = Error,
+                    color = colorScheme.error,
                     style = MaterialTheme.typography.bodySmall,
                     modifier =
                         Modifier.fillMaxWidth()
@@ -431,7 +430,7 @@ fun InvitationResultDialog(
             Triple(
                 stringResource(R.string.staff_invitation_error_title),
                 stringResource(R.string.staff_invitation_error_message, userName),
-                Error)
+                colorScheme.error)
       }
 
   AlertDialog(


### PR DESCRIPTION
## Description

This PR fixes an inconsistency where a color was not using `colorScheme` as intended. The affected color now correctly uses `colorScheme.error`, making the code clearer and more consistent. No other colors were affected.

## Related Issues

Closes #494 (Sub-Issue of #289)

## How to Test

1. Run the app and trigger a scenario that displays the error color.  
2. Verify that the correct `colorScheme.error` color is applied.  
3. Read the code and check that `colorScheme` is used consistently wherever needed.