### PR TITLE
test(nav): Inject mocks into MapViewModel for full navigation test

### DIFF
--- a/app/src/androidTest/java/ch/onepass/onepass/ui/navigation/FullNavigationTest.kt
+++ b/app/src/androidTest/java/ch/onepass/onepass/ui/navigation/FullNavigationTest.kt
@@ -17,12 +17,14 @@ import androidx.test.rule.GrantPermissionRule
 import ch.onepass.onepass.BuildConfig
 import ch.onepass.onepass.OnePassApp
 import ch.onepass.onepass.model.auth.AuthRepositoryFirebase
+import ch.onepass.onepass.model.event.EventRepository
 import ch.onepass.onepass.model.user.UserRepositoryFirebase
 import ch.onepass.onepass.ui.auth.AuthViewModel
 import ch.onepass.onepass.ui.feed.FeedScreenTestTags
 import ch.onepass.onepass.ui.map.MapViewModel
 import ch.onepass.onepass.ui.myevents.MyEventsTestTags
 import ch.onepass.onepass.ui.profile.*
+import ch.onepass.onepass.utils.TimeProvider
 import com.mapbox.common.MapboxOptions
 import io.mockk.*
 import kotlinx.coroutines.Job
@@ -76,10 +78,13 @@ class FullNavigationTest {
           }
     }
 
+    val mockEventRepo = mockk<EventRepository>(relaxed = true)
+    val mockTimeProvider = mockk<TimeProvider>(relaxed = true)
+
     composeRule.setContent {
       OnePassApp(
           navController = navController,
-          mapViewModel = MapViewModel(),
+          mapViewModel = MapViewModel(mockEventRepo, mockTimeProvider),
           testAuthButtonTag = if (!signedIn) TEST_LOGIN_BUTTON else null,
           authViewModelFactory = authVmFactory,
           profileViewModelFactory = injectedProfileVMFactory,

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -30,6 +30,22 @@
         { "fieldPath": "eventId", "order": "ASCENDING" },
         { "fieldPath": "listingPrice", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "organizerId", "order": "ASCENDING" },
+        { "fieldPath": "startTime", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "startTime", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
This commit updates the `FullNavigationTest` to properly inject mock dependencies into the `MapViewModel`.

Key changes:
- `EventRepository` and `TimeProvider` are now mocked.
- The `MapViewModel` is instantiated with these mocks to ensure isolated and predictable behavior during navigation testing.